### PR TITLE
Run triqs without MPI 

### DIFF
--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -91,7 +91,10 @@ namespace mpi {
     }
 
     void abort(int error_code) {
-      if (has_env) { MPI_Abort(_com, error_code); }
+      if (has_env)
+        MPI_Abort(_com, error_code);
+      else
+        std::abort();
     }
 
 #ifdef BOOST_MPI_HPP

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -157,10 +157,10 @@ namespace mpi {
       if constexpr (is_std_vector<T>) {
         T res;
         res.reserve(v.size());
-        for (auto &x : v) res.emplace_back(std::move(x));
+        for (auto &x : v) res.emplace_back(convert<typename T::value_type>(std::move(x)));
         return res;
       } else
-        return std::move(v);
+        return T{std::move(v)};
     }
   } // namespace details
 

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -51,7 +51,6 @@ namespace mpi {
 
   // ------------------------------------------------------------
 
-
   /// The communicator. Todo : add more constructors.
   class communicator {
     MPI_Comm _com = MPI_COMM_WORLD;
@@ -126,12 +125,6 @@ namespace mpi {
     MPI_Op op{};
   };
 
-  template <typename T>
-  inline constexpr bool is_mpi_lazy = false;
-
-  template <typename Tag, typename T>
-  inline constexpr bool is_mpi_lazy<lazy<Tag, T>> = true;
-
   // ----------------------------------------
   // ------- general functions -------
   // ----------------------------------------
@@ -143,6 +136,12 @@ namespace mpi {
   }
 
   namespace details {
+
+    template <typename T>
+    inline constexpr bool is_mpi_lazy = false;
+
+    template <typename Tag, typename T>
+    inline constexpr bool is_mpi_lazy<lazy<Tag, T>> = true;
 
     template <typename T>
     inline constexpr bool is_std_vector = false;
@@ -166,7 +165,7 @@ namespace mpi {
   [[gnu::always_inline]] inline decltype(auto) reduce(T &&x, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     using r_t = decltype(mpi_reduce(std::forward<T>(x), c, root, all, op));
 
-    if constexpr (is_mpi_lazy<r_t>) {
+    if constexpr (details::is_mpi_lazy<r_t>) {
       return mpi_reduce(std::forward<T>(x), c, root, all, op);
     } else {
       if (has_env)
@@ -186,7 +185,7 @@ namespace mpi {
   [[gnu::always_inline]] inline decltype(auto) scatter(T &&x, mpi::communicator c = {}, int root = 0) {
     using r_t = decltype(mpi_scatter(std::forward<T>(x), c, root));
 
-    if constexpr (is_mpi_lazy<r_t>) {
+    if constexpr (details::is_mpi_lazy<r_t>) {
       return mpi_scatter(std::forward<T>(x), c, root);
     } else {
       if (has_env)
@@ -200,7 +199,7 @@ namespace mpi {
   [[gnu::always_inline]] inline decltype(auto) gather(T &&x, mpi::communicator c = {}, int root = 0, bool all = false) {
     using r_t = decltype(mpi_gather(std::forward<T>(x), c, root, all));
 
-    if constexpr (is_mpi_lazy<r_t>) {
+    if constexpr (details::is_mpi_lazy<r_t>) {
       return mpi_gather(std::forward<T>(x), c, root, all);
     } else {
       if (has_env)

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -31,6 +31,10 @@ namespace mpi {
 
   // ------------------------------------------------------------
 
+  /* helper function to check for MPI runtime environment
+   * covers at the moment OpenMPI, MPICH, and intelmpi
+   * as cray uses MPICH under the hood it should work as well 
+   */
   static const bool has_env = []() {
     if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr)
       return true;
@@ -191,6 +195,7 @@ namespace mpi {
     if constexpr (details::is_mpi_lazy<r_t>) {
       return mpi_scatter(std::forward<T>(x), c, root);
     } else {
+      // if it does not have a mpi lazy type, check manually if triqs is run with MPI
       if (has_env)
         return mpi_scatter(std::forward<T>(x), c, root);
       else
@@ -205,6 +210,7 @@ namespace mpi {
     if constexpr (details::is_mpi_lazy<r_t>) {
       return mpi_gather(std::forward<T>(x), c, root, all);
     } else {
+      // if it does not have a mpi lazy type, check manually if triqs is run with MPI
       if (has_env)
         return mpi_gather(std::forward<T>(x), c, root, all);
       else

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -43,13 +43,9 @@ namespace mpi {
   };
 
   // ------------------------------------------------------------
-  
+
   /// MPI env state variable
-  enum class MPI_ENV {
-      Unchecked,
-      False,
-      True
-  };
+  enum class MPI_ENV { Unchecked, False, True };
 
   inline MPI_ENV check_mpi_env() {
     if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr)
@@ -61,7 +57,7 @@ namespace mpi {
   /// The communicator. Todo : add more constructors.
   class communicator {
     MPI_Comm _com = MPI_COMM_WORLD;
-    
+
     inline static MPI_ENV _mpi_env = MPI_ENV::Unchecked;
 
     public:
@@ -92,16 +88,16 @@ namespace mpi {
         return num;
       } else
         return 1;
-    }  
+    }
 
     [[nodiscard]] communicator split(int color, int key = 0) const {
       if (_mpi_env == MPI_ENV::True) {
-          communicator c;
-          MPI_Comm_split(_com, color, key, &c._com);
-          return c;
+        communicator c;
+        MPI_Comm_split(_com, color, key, &c._com);
+        return c;
       } else
-//TODO split should not be done without MPI? 
-          return 0;
+        //TODO split should not be done without MPI?
+        return 0;
     }
 
     void abort(int error_code) {
@@ -164,12 +160,12 @@ namespace mpi {
     } else
       return decltype(mpi_reduce(std::forward<T>(x), c, root, all, op))(std::forward<T>(x));
   }
-  
+
   template <typename T>
   [[gnu::always_inline]] inline void reduce_in_place(T &&x, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     if (mpi::check_mpi_env() == MPI_ENV::True) { return mpi_reduce_in_place(std::forward<T>(x), c, root, all, op); }
   }
-  
+
   template <typename T>
   [[gnu::always_inline]] inline decltype(auto) scatter(T &&x, mpi::communicator c = {}, int root = 0) {
     if (mpi::check_mpi_env() == MPI_ENV::True) {
@@ -177,7 +173,7 @@ namespace mpi {
     } else
       return decltype(mpi_scatter(std::forward<T>(x), c, root))(std::forward<T>(x));
   }
-  
+
   template <typename T>
   [[gnu::always_inline]] inline decltype(auto) gather(T &&x, mpi::communicator c = {}, int root = 0, bool all = false) {
     if (mpi::check_mpi_env() == MPI_ENV::True) {
@@ -398,20 +394,15 @@ namespace mpi {
       MPI_Allreduce(MPI_IN_PLACE, &a, 1, mpi_type<T>::get(), op, c.get());
   }
 
-#define MPI_TEST_MAIN      \
-  int main(int argc, char **argv) {  \
-\
-    ::testing::InitGoogleTest(&argc, argv); \
-    if (mpi::check_mpi_env() == mpi::MPI_ENV::True) { \
-      mpi::environment env(argc, argv); \
-      std::cout << "MPI environment detected" \
-                << "\n";   \
-    return RUN_ALL_TESTS(); \
-    } \
-    else { \
-    return RUN_ALL_TESTS(); \
-    } \
-    \
-  } 
+#define MPI_TEST_MAIN                                                                                                                                \
+  int main(int argc, char **argv) {                                                                                                                  \
+    ::testing::InitGoogleTest(&argc, argv);                                                                                                          \
+    if (mpi::check_mpi_env() == mpi::MPI_ENV::True) {                                                                                                \
+      mpi::environment env(argc, argv);                                                                                                              \
+      std::cout << "MPI environment detected\n";                                                                                                     \
+      return RUN_ALL_TESTS();                                                                                                                        \
+    } else                                                                                                                                           \
+      return RUN_ALL_TESTS();                                                                                                                        \
+  }
 
 } // namespace mpi

--- a/test/c++/CMakeLists.txt
+++ b/test/c++/CMakeLists.txt
@@ -7,6 +7,11 @@ endforeach()
 # List of all tests
 file(GLOB_RECURSE all_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
+# List of all no mpi tests
+file(GLOB_RECURSE nompi_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
+# remove custom mpi test, as this one explicitly uses MPI
+list(REMOVE_ITEM nompi_tests mpi_custom.cpp)
+
 # ========= OpenMP Dependency ==========
 
 find_package(OpenMP REQUIRED COMPONENTS CXX)
@@ -23,9 +28,34 @@ foreach(test ${all_tests})
   target_link_libraries(${test_name} ${PROJECT_NAME}::${PROJECT_NAME}_c openmp ${PROJECT_NAME}_warnings gtest_main)
   set_property(TARGET ${test_name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   set(test_bin ${CMAKE_CURRENT_BINARY_DIR}/${test_dir}/${test_name})
-  add_test(NAME ${test_name}_np1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${test_bin} ${MPIEXEC_POSTFLAGS} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
-  add_test(NAME ${test_name}_np2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ${test_bin} ${MPIEXEC_POSTFLAGS} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
+  add_test(NAME ${test_name}_np2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${test_bin} ${MPIEXEC_POSTFLAGS} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   add_test(NAME ${test_name}_np4 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} ${test_bin} ${MPIEXEC_POSTFLAGS} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
+  # Run clang-tidy if found
+  if(CLANG_TIDY_EXECUTABLE)
+    set_target_properties(${test_name} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE}")
+  endif()
+  # Run cppcheck if found
+  if(CPPCHECK_EXECUTABLE)
+    add_custom_command(
+      TARGET ${test_name}
+      COMMAND ${CPPCHECK_EXECUTABLE}
+      --enable=warning,style,performance,portability
+      --std=c++17
+      --template=gcc
+      --verbose
+      --force
+      --quiet
+      ${CMAKE_CURRENT_SOURCE_DIR}/${test}
+    )
+  endif()
+endforeach()
+
+# now the no mpi tests
+foreach(test ${nompi_tests})
+  get_filename_component(test_name ${test} NAME_WE)
+  get_filename_component(test_dir ${test} DIRECTORY)
+  set(test_bin ${CMAKE_CURRENT_BINARY_DIR}/${test_dir}/${test_name})
+  add_test(NAME ${test_name}_nompi COMMAND ${test_bin} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   # Run clang-tidy if found
   if(CLANG_TIDY_EXECUTABLE)
     set_target_properties(${test_name} PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY_EXECUTABLE}")

--- a/test/c++/CMakeLists.txt
+++ b/test/c++/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB_RECURSE all_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 # List of all no mpi tests
 file(GLOB_RECURSE nompi_tests RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 # remove custom mpi test, as this one explicitly uses MPI
-list(REMOVE_ITEM nompi_tests mpi_custom.cpp)
+list(REMOVE_ITEM nompi_tests mpi_custom.cpp mpi_monitor.cpp)
 
 # ========= OpenMP Dependency ==========
 


### PR DESCRIPTION
see https://github.com/TRIQS/triqs/pull/809 for more details. But this PR allows to run triqs without MPI by checking for an valid MPI env when the MPI communicator is created. If no MPI env is found, simplified versions of MPI routines are called. Tests are now run also without MPI.