### PR TITLE
New poll_barrier as alternative to mpi.barrier

### DIFF
--- a/test/c++/mpi_barrier.cpp
+++ b/test/c++/mpi_barrier.cpp
@@ -1,0 +1,33 @@
+#include "mpi/mpi.hpp"
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace mpi;
+
+TEST(MPI, barrier) {
+
+  communicator world{};
+
+  if (world.rank() == 0) {
+    // Pretend to do something only in rank 0
+    sleep(1);
+  }
+  // synchronize all ranks calling the normal MPI_barrier function by providing 0 as arg
+  world.barrier(0);
+  // now do the same with the poll barrier which reduces CPU load
+  // to clearly the difference in htop one can simply set sleep(10)
+  if (world.rank() == 0) {
+    // Pretend to do something only in rank 0
+    sleep(1);
+  }
+  // synchronize all ranks each 0.1 sec
+  world.barrier(100);
+  if (world.rank() == 0) {
+    // Pretend to do something only in rank 0
+    sleep(1);
+  }
+  // synchronize all ranks each 0.1 sec
+  world.barrier(100);
+}
+
+MPI_TEST_MAIN;


### PR DESCRIPTION
MPI_Barrier produces 100% CPU load on waiting mpi ranks. As an
alternative one can combine a non blocking MPI_IBarrier with MPI_Test
each X milliseconds to only check every so often if all ranks reached
the barrier. Already X=100msec reduces the CPU load below 1% load,
making it possible to use the rank for other tasks in MPI / OpenMP
hybrid settings, or allowing more efficient thermal use of the CPU.

Thanks to A. Pataki for helping!

Changes:
- implement function barrier(msec) to check only each msec the
  barrier
- new default barrier function -> 0msec as polling freq. calls normal MPI_Barrier
-  default value for polling is 10msec
- add test mpi_barrier.cpp
