### PR TITLE
[cray-mpich] add support by EnvVar and demote CXX types to C

### DIFF
--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -41,7 +41,7 @@ namespace mpi {
    * as cray uses MPICH under the hood it should work as well
    */
   static const bool has_env = []() {
-    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("pmi_rank") != nullptr or std::getenv("CRAY_MPICH_VERSION") != nullptr)
+    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr or std::getenv("CRAY_MPICH_VERSION") != nullptr)
       return true;
     else
       return false;

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -41,7 +41,7 @@ namespace mpi {
    * as cray uses MPICH under the hood it should work as well
    */
   static const bool has_env = []() {
-    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr)
+    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("pmi_rank") != nullptr or std::getenv("CRAY_MPICH_VERSION") != nullptr)
       return true;
     else
       return false;
@@ -292,14 +292,14 @@ namespace mpi {
   }
   template <typename T>
   struct mpi_type<const T> : mpi_type<T> {};
-  D(bool, MPI_CXX_BOOL);
+  D(bool, MPI_C_BOOL);
   D(char, MPI_CHAR);
   D(int, MPI_INT);
   D(long, MPI_LONG);
   D(long long, MPI_LONG_LONG);
   D(double, MPI_DOUBLE);
   D(float, MPI_FLOAT);
-  D(std::complex<double>, MPI_CXX_DOUBLE_COMPLEX);
+  D(std::complex<double>, MPI_C_DOUBLE_COMPLEX);
   D(unsigned long, MPI_UNSIGNED_LONG);
   D(unsigned int, MPI_UNSIGNED);
   D(unsigned long long, MPI_UNSIGNED_LONG_LONG);

--- a/test/c++/mpi_cplx.cpp
+++ b/test/c++/mpi_cplx.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Hugo U. R. Strand
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Hugo U. R. Strand
+
+#include <mpi/mpi.hpp>
+#include <gtest/gtest.h>
+
+#include <complex>
+
+TEST(MPI, complex_broadcast) {
+
+  mpi::communicator world;
+
+  std::complex<double> cplx;
+  if (world.rank() == 0) cplx = std::complex<double>(1., 2.);
+
+  mpi::broadcast(cplx);
+
+  EXPECT_EQ(cplx, std::complex<double>(1., 2.));
+}
+
+MPI_TEST_MAIN;


### PR DESCRIPTION
This pull requests makes the modifications required to support Cray/HPE MPICH 8.1.18.

This (most recent, June 2022) version of MPICH does not support the C++ types, hence the change demotes the C++ types to the C equivalents, i.e.
```
MPI_CXX_BOOL --> MPI_C_BOOL
MPI_CXX_DOUBLE_COPLEX --> MPI_C_DOUBLE_COMPLEX
```

Additionally the MPICK environment is detected by adding the environment variable `CRAY_MPICH_VERSION` to the list of "accepted environment variables".

The type demotion does not affect the reduction etc since the memory footprint is the same.

Please consider merging.

(I have also added a simple `mpi_cplx` test that broadcasts a complex. This shows the issue with the unsupported `MPI_CXX_DOUBLE_COMPLEX` types.)