### PR TITLE
[mpi] add envar check to force MPI init

### DIFF
--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -39,9 +39,12 @@ namespace mpi {
   /* helper function to check for MPI runtime environment
    * covers at the moment OpenMPI, MPICH, and intelmpi
    * as cray uses MPICH under the hood it should work as well
+   * TRIQS_FORCE_MPI_INIT can be used to overwrite manually on
+   * on runtime.
    */
   static const bool has_env = []() {
-    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr or std::getenv("CRAY_MPICH_VERSION") != nullptr)
+    if (std::getenv("OMPI_COMM_WORLD_RANK") != nullptr or std::getenv("PMI_RANK") != nullptr or std::getenv("CRAY_MPICH_VERSION") != nullptr
+        or std::getenv("TRIQS_FORCE_MPI_INIT") != nullptr)
       return true;
     else
       return false;


### PR DESCRIPTION
Add check for environment variable `TRIQS_FORCE_MPI_INIT` to allow enforcing the MPI Init for specific environments and test cases. Should address TRIQS/cthyb issue #166 (https://github.com/TRIQS/cthyb/issues/166)