### PR TITLE
Generalize the monitor class

### DIFF
--- a/c++/mpi/communicator.hpp
+++ b/c++/mpi/communicator.hpp
@@ -99,6 +99,37 @@ namespace mpi {
     }
 
     /**
+     * @brief Duplicate the communicator.
+     *
+     * @details Calls `MPI_Comm_dup` to duplicate the communicator. See the MPI documentation for more details, e.g.
+     * <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_dup.3.html">open-mpi docs</a>.
+     *
+     * @return If mpi::has_env is true, return the duplicated `MPI_Comm` object wrapped in a new mpi::communicator,
+     * otherwise return a default constructed mpi::communicator.
+     */
+    [[nodiscard]] communicator duplicate() const {
+      if (has_env) {
+        communicator c;
+        MPI_Comm_dup(_com, &c._com);
+        return c;
+      } else
+        return {};
+    }
+
+    /**
+     * @brief Free the communicator.
+     *
+     * @details Calls `MPI_Comm_free` to mark the communicator for deallocation. See the MPI documentation for more
+     * details, e.g. <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_free.3.html">open-mpi docs
+     * </a>.
+     *
+     * Does nothing, if mpi::has_env is false.
+     */
+    void free() {
+      if (has_env) { MPI_Comm_free(&_com); }
+    }
+
+    /**
      * @brief If mpi::has_env is true, `MPI_Abort` is called with the given error code, otherwise std::abort is called.
      * @param error_code The error code to pass to `MPI_Abort`.
      */

--- a/c++/mpi/communicator.hpp
+++ b/c++/mpi/communicator.hpp
@@ -86,6 +86,9 @@ namespace mpi {
      * @details Calls `MPI_Comm_split` with the given color and key arguments. See the MPI documentation for more details,
      * e.g. <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_split.3.html">open-mpi docs</a>.
      *
+     * @warning This allocates a new communicator object. Make sure to call `free` on the returned communicator when
+     * it is no longer needed.
+     *
      * @return If mpi::has_env is true, return the split `MPI_Comm` object wrapped in a new mpi::communicator, otherwise
      * return a default constructed mpi::communicator.
      */
@@ -103,6 +106,9 @@ namespace mpi {
      *
      * @details Calls `MPI_Comm_dup` to duplicate the communicator. See the MPI documentation for more details, e.g.
      * <a href="https://docs.open-mpi.org/en/v5.0.x/man-openmpi/man3/MPI_Comm_dup.3.html">open-mpi docs</a>.
+     *
+     * @warning This allocates a new communicator object. Make sure to call `free` on the returned communicator when
+     * it is no longer needed.
      *
      * @return If mpi::has_env is true, return the duplicated `MPI_Comm` object wrapped in a new mpi::communicator,
      * otherwise return a default constructed mpi::communicator.

--- a/c++/mpi/monitor.hpp
+++ b/c++/mpi/monitor.hpp
@@ -36,13 +36,13 @@ namespace mpi {
    * @brief Constructed on top of an MPI communicator, this class helps to monitor and communicate events across
    * multiple processes.
    *
-   * @details The root process monitors all other processes. If a process encounters an event, it sends a message to the
-   * root process by calling monitor::report_local_event. The root process then broadcasts this information to all other
-   * processes.
+   * @details The root process (rank == 0) monitors all other processes. If a process encounters an event, it sends a
+   * message to the root process by calling monitor::report_local_event. The root process then broadcasts this
+   * information to all other processes.
    *
    * It can be used to check
-   * - if an event has occurred on at least one process (monitor::some_event_occurred) or
-   * - if an event has occurred on all processes (monitor::all_events_occurred).
+   * - if an event has occurred on any process (monitor::event_on_any_rank) or
+   * - if an event has occurred on all processes (monitor::event_on_all_ranks).
    */
   class monitor {
     // Future struct for non-blocking MPI communication.
@@ -57,16 +57,13 @@ namespace mpi {
     // MPI communicator.
     mpi::communicator comm;
 
-    // Root rank.
-    int root = 0;
-
     // Future objects stored on the root process for local events on non-root processes.
     std::vector<future> root_futures;
 
-    // MPI request for the broadcasting done on the root process in case some event has occurred.
-    MPI_Request req_ibcast_some{};
+    // MPI request for the broadcasting done on the root process in case an event has occurred on any rank.
+    MPI_Request req_ibcast_any{};
 
-    // MPI request for the broadcasting done on the root process in case an event has occurred on all processes.
+    // MPI request for the broadcasting done on the root process in case an event has occurred on all ranks.
     MPI_Request req_ibcast_all{};
 
     // MPI request for the sending done on non-root processes.
@@ -75,8 +72,8 @@ namespace mpi {
     // Set to 1, if a local event has occurred on this process.
     int local_event = 0;
 
-    // Set to 1, if an event has occurred on some process.
-    int some_event = 0;
+    // Set to 1, if an event has occurred on any process.
+    int any_event = 0;
 
     // Set to 1, if an event has occurred on all processes.
     int all_events = 0;
@@ -88,22 +85,22 @@ namespace mpi {
     /**
      * @brief Construct a monitor on top of a given mpi::communicator.
      *
-     * @details The root process performs a non-blocking receive for every non-root process and waits for a non-root
-     * process to send a message that an event has occurred.
+     * @details The root process (rank == 0) performs a non-blocking receive for every non-root process and waits for a
+     * non-root process to send a message that an event has occurred.
      *
      * Non-root processes make two non-blocking broadcast calls and wait for the root process to broadcast a message in
-     * case an event has occurred on some process or on all processes.
+     * case an event has occurred on any or on all processes.
      *
      * @param c mpi::communicator.
      */
-    monitor(mpi::communicator c, int root = 0) : comm(c), root(root) {
-      if (comm.rank() == root) {
+    monitor(mpi::communicator c) : comm(c) {
+      if (comm.rank() == 0) {
         root_futures.resize(c.size() - 1);
         for (int rank = 1; rank < c.size(); ++rank) {
           MPI_Irecv(&(root_futures[rank - 1].event), 1, MPI_INT, rank, 0, comm.get(), &(root_futures[rank - 1].request));
         }
       } else {
-        MPI_Ibcast(&some_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_some);
+        MPI_Ibcast(&any_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_any);
         MPI_Ibcast(&all_events, 1, MPI_INT, 0, comm.get(), &req_ibcast_all);
       }
     }
@@ -118,11 +115,11 @@ namespace mpi {
     ~monitor() { finalize_communications(); }
 
     /**
-     * @brief Report a local event to the root process.
+     * @brief Report a local event to the root process (rank == 0).
      *
      * @details This function can be called on any process in case a local event has occurred.
      *
-     * On the root process, it immediately broadcasts to all other processes that some event has occurred and further
+     * On the root process, it immediately broadcasts to all other processes that an event has occurred and further
      * checks if all other processes have reported an event as well. If so, it additionally broadcasts to all processes
      * that an event has occurred on all processes.
      *
@@ -134,7 +131,7 @@ namespace mpi {
 
       // a local event has occurred
       local_event = 1;
-      if (comm.rank() == root) {
+      if (comm.rank() == 0) {
         // on root process, check all other nodes and perform necessary broadcasts
         root_check_nodes_and_bcast();
       } else {
@@ -144,7 +141,7 @@ namespace mpi {
     }
 
     /**
-     * @brief Check if an event has occurred on some process.
+     * @brief Check if an event has occurred on any process.
      *
      * @details This function can be called on any process to check if an event has occurred somewhere.
      *
@@ -153,31 +150,31 @@ namespace mpi {
      * - if an event has occurred on some other process which has already been reported to the root process and
      * broadcasted to all other processes.
      *
-     * On the root process, it checks the status of all non-root processes and performs the necessary broadcasts in case
-     * they have not been done yet.
+     * On the root process (rank == 0), it checks the status of all non-root processes and performs the necessary
+     * broadcasts in case they have not been done yet.
      *
-     * @return True, if an event has occurred on some process.
+     * @return True, if an event has occurred on any process.
      */
-    [[nodiscard]] bool some_event_occurred() {
-      // if final_communications() has already been called, some_event == 0 if no event has occurred, otherwise it is 1
-      if (finalized) return some_event;
+    [[nodiscard]] bool event_on_any_rank() {
+      // if final_communications() has already been called, any_event == 0 if no event has occurred, otherwise it is 1
+      if (finalized) return any_event;
 
       // if a local event has occurred, we return true
       if (local_event) return true;
 
       // on the root process, we first check the status of all non-root processes, perform the necessary broadcasts and
       // return true if an event has occurred
-      if (comm.rank() == root) {
+      if (comm.rank() == 0) {
         root_check_nodes_and_bcast();
-        return some_event;
+        return any_event;
       }
 
       // on non-root processes, we check the status of the corresponding broadcast and return true if an event has
       // occurred
       MPI_Status status;
-      int flag = 0;
-      MPI_Test(&req_ibcast_some, &flag, &status);
-      return flag and some_event;
+      int has_received = 0;
+      MPI_Test(&req_ibcast_any, &has_received, &status);
+      return has_received and any_event;
     }
 
     /**
@@ -188,19 +185,19 @@ namespace mpi {
      * It returns true, if an event has occurred on all processes which has already been reported to the root process
      * and broadcasted to all other processes.
      *
-     * On the root process, it checks the status of all non-root processes and performs the necessary broadcasts in case
-     * it has not been done yet.
+     * On the root process (rank == 0), it checks the status of all non-root processes and performs the necessary
+     * broadcasts in case it has not been done yet.
      *
      * @return True, if an event has occurred on all processes.
      */
-    [[nodiscard]] bool all_events_occurred() {
+    [[nodiscard]] bool event_on_all_ranks() {
       // if final_communications() has already been called, all_events == 0 if an event has not occurred on every
       // process, otherwise it is 1
       if (finalized) return all_events;
 
       // on the root process, we first check the status of all non-root processes, perform the necessary broadcasts and
-      // return true if an event has occurred
-      if (comm.rank() == root) {
+      // return true if an event has occurred on all of them
+      if (comm.rank() == 0) {
         root_check_nodes_and_bcast();
         return all_events;
       }
@@ -208,9 +205,9 @@ namespace mpi {
       // on non-root processes, we check the status of the broadcast and return true if an event has occurred on all
       // processes
       MPI_Status status;
-      int flag = 0;
-      MPI_Test(&req_ibcast_all, &flag, &status);
-      return flag and all_events;
+      int has_received = 0;
+      MPI_Test(&req_ibcast_all, &has_received, &status);
+      return has_received and all_events;
     }
 
     /**
@@ -220,16 +217,16 @@ namespace mpi {
      * variables will not change anymore due to some member function calls.
      */
     void finalize_communications() {
-      // preven multiple calls
+      // prevent multiple calls
       if (finalized) return;
 
-      if (comm.rank() == root) {
+      if (comm.rank() == 0) {
         // on root process, wait for all non-root processes to finish their MPI_Isend calls
         while (root_check_nodes_and_bcast()) {
           usleep(100); // 100 us (micro seconds)
         }
         // and perform broadcasts in case they have not been done yet
-        if (not some_event) { MPI_Ibcast(&some_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_some); }
+        if (not any_event) { MPI_Ibcast(&any_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_any); }
         if (not all_events) { MPI_Ibcast(&all_events, 1, MPI_INT, 0, comm.get(), &req_ibcast_all); }
       } else {
         // on non-root processes, perform MPI_Isend call in case it has not been done yet
@@ -237,51 +234,37 @@ namespace mpi {
       }
 
       // all nodes wait for the broadcasts to be completed
-      MPI_Status status_some, status_all;
-      MPI_Wait(&req_ibcast_some, &status_some);
+      MPI_Status status_any, status_all;
+      MPI_Wait(&req_ibcast_any, &status_any);
       MPI_Wait(&req_ibcast_all, &status_all);
       finalized = true;
     }
 
     private:
-    // Root process broadcasts that some event has occurred on some process in case it has not done so yet.
-    void root_bcast_some_event() {
-      EXPECTS(!finalized);
-      EXPECTS(com.rank() == root);
-      if (not some_event) {
-        some_event = 1;
-        MPI_Ibcast(&some_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_some);
-      }
-    }
-
-    // Root process broadcasts that an event has occurred on all processes in case it has not done so yet.
-    void root_bcast_all_events() {
-      EXPECTS(!finalized);
-      EXPECTS(com.rank() == root);
-      if (not all_events) {
-        all_events = 1;
-        MPI_Ibcast(&all_events, 1, MPI_INT, 0, comm.get(), &req_ibcast_all);
-      }
-    }
-
     // Root process checks the status of all non-root processes, performs necessary broadcasts and returns a boolean
     // that is true if at least one non-root process has not performed its MPI_Isend call yet.
     bool root_check_nodes_and_bcast() {
       EXPECTS(!finalized);
-      EXPECTS(com.rank() == root);
-      bool some     = false;
+      EXPECTS(comm.rank() == root);
+      bool any      = false;
       bool all      = true;
       bool finished = true;
       for (auto &[request, event] : root_futures) {
         MPI_Status status;
-        int flag = 0;
-        MPI_Test(&request, &flag, &status);
-        some |= (flag and event);
-        all &= (flag and event);
-        finished &= flag;
+        int has_received = 0;
+        MPI_Test(&request, &has_received, &status);
+        any |= (has_received and event);
+        all &= (has_received and event);
+        finished &= has_received;
       }
-      if (some or local_event) root_bcast_some_event();
-      if (all and local_event) root_bcast_all_events();
+      if (not any_event and (any or local_event)) {
+        any_event = 1;
+        MPI_Ibcast(&any_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_any);
+      }
+      if (not all_events and all and local_event) {
+        all_events = 1;
+        MPI_Ibcast(&all_events, 1, MPI_INT, 0, comm.get(), &req_ibcast_all);
+      }
       return not finished;
     }
   };

--- a/c++/mpi/monitor.hpp
+++ b/c++/mpi/monitor.hpp
@@ -259,13 +259,13 @@ namespace mpi {
       bool any      = false;
       bool all      = true;
       bool finished = true;
-      for (auto &[request, event] : root_futures) {
+      for (auto &[request, rank_event] : root_futures) {
         MPI_Status status;
-        int has_received = 0;
-        MPI_Test(&request, &has_received, &status);
-        any |= (has_received and event);
-        all &= (has_received and event);
-        finished &= has_received;
+        int rank_received = 0;
+        MPI_Test(&request, &rank_received, &status);
+        any |= (rank_received and rank_event);
+        all &= (rank_received and rank_event);
+        finished &= rank_received;
       }
       if (not any_event and (any or local_event)) {
         any_event = 1;

--- a/c++/mpi/monitor.hpp
+++ b/c++/mpi/monitor.hpp
@@ -102,7 +102,7 @@ namespace mpi {
       if (comm.rank() == 0) {
         root_futures.resize(c.size() - 1);
         for (int rank = 1; rank < c.size(); ++rank) {
-          MPI_Irecv(&(root_futures[rank - 1].event), 1, MPI_INT, rank, 0, comm.get(), &(root_futures[rank - 1].request));
+          MPI_Irecv(&(root_futures[rank - 1].event), 1, MPI_INT, rank, rank, comm.get(), &(root_futures[rank - 1].request));
         }
       } else {
         MPI_Ibcast(&any_event, 1, MPI_INT, 0, comm.get(), &req_ibcast_any);
@@ -141,7 +141,7 @@ namespace mpi {
         root_check_nodes_and_bcast();
       } else {
         // on non-root processes, let the root process know about the local event
-        MPI_Isend(&local_event, 1, MPI_INT, 0, 0, comm.get(), &req_isent);
+        MPI_Isend(&local_event, 1, MPI_INT, 0, comm.rank(), comm.get(), &req_isent);
       }
     }
 
@@ -237,7 +237,7 @@ namespace mpi {
         if (not all_events) { MPI_Ibcast(&all_events, 1, MPI_INT, 0, comm.get(), &req_ibcast_all); }
       } else {
         // on non-root processes, perform MPI_Isend call in case it has not been done yet
-        if (not local_event) { MPI_Isend(&local_event, 1, MPI_INT, 0, 0, comm.get(), &req_isent); }
+        if (not local_event) { MPI_Isend(&local_event, 1, MPI_INT, 0, comm.rank(), comm.get(), &req_isent); }
       }
 
       // all nodes wait for the broadcasts to be completed

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -84,7 +84,7 @@
         <tab type="user" url="@ref mpi::tag::scatter" title="scatter tag"/>
         <tab type="user" url="@ref mpi::is_mpi_lazy" title="is_mpi_lazy"/>
       </tab>
-      <tab type="usergroup" url="@ref err_handling" title="Error handling">
+      <tab type="usergroup" url="@ref event_handling" title="Event handling">
         <tab type="user" url="@ref mpi::monitor" title="monitor"/>
       </tab>
       <tab type="usergroup" url="@ref utilities" title="Utilities">

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -68,9 +68,10 @@ Most users probably won't need to use this functionality directly.
 
 We refer the interested reader to [TRIQS/nda](https://github.com/TRIQS/nda/blob/unstable/c%2B%2B/nda/mpi/reduce.hpp) for more details.
 
-## Error handling
+## Event handling
 
-@ref err_handling provides the mpi::monitor class which can be used to communicate and handle errors across multiple processes.
+@ref event_handling provides the mpi::monitor class which can be used to communicate and handle events across multiple
+processes.
 
 @ref ex2 shows a simple use case.
 

--- a/doc/ex2.md
+++ b/doc/ex2.md
@@ -20,7 +20,7 @@ int main(int argc, char *argv[]) {
   // in case an event has occurred, print some info and return true
   auto stop = [&monitor, world](int i) {
     bool res = false;
-    if (monitor.some_event_occurred()) {
+    if (monitor.event_on_any_rank()) {
       std::cerr << "Processor " << world.rank() << ": After " << i << " steps an event has been communicated.\n";
       res = true;
     }
@@ -42,8 +42,8 @@ int main(int argc, char *argv[]) {
 
   // check if all processes finished the loop
   if (world.rank() == 0) {
-    if (monitor.some_event_occurred()) {
-      std::cout << "Oh no! An event occurred somewhere and loop has not been finished on all processes.\n";
+    if (monitor.event_on_any_rank()) {
+      std::cout << "Oh no! An event occurred somewhere and the loop has not been finished on all processes.\n";
     } else {
       std::cout << "No worries, all processes have finished the loop.\n";
     }

--- a/doc/ex2.md
+++ b/doc/ex2.md
@@ -17,35 +17,35 @@ int main(int argc, char *argv[]) {
   // initialize monitor
   mpi::monitor monitor(world);
 
-  // in case a stop has been requested, print some info and return true
+  // in case an event has occurred, print some info and return true
   auto stop = [&monitor, world](int i) {
     bool res = false;
-    if (monitor.emergency_occured()) {
-      std::cerr << "Processor " << world.rank() << ": After " << i << " steps an emergency stop has been received.\n";
+    if (monitor.some_event_occurred()) {
+      std::cerr << "Processor " << world.rank() << ": After " << i << " steps an event has been communicated.\n";
       res = true;
     }
     return res;
   };
 
-  // loop as long as no stop has been requested
-  int rank_to_req = 3;
+  // loop as long as no event has occurred
+  int event_rank = 3;
   for (int i = 0; i < 1000000; ++i) {
-    // request a stop on processor 3
-    if (world.rank() == rank_to_req) {
-      std::cerr << "Processor " << rank_to_req << ": Emergency stop requested.\n";
-      monitor.request_emergency_stop();
+    // report a local event on the event_rank
+    if (world.rank() == event_rank) {
+      std::cerr << "Processor " << event_rank << ": Local event reported.\n";
+      monitor.report_local_event();
     }
 
     // should we stop the loop?
     if (stop(i)) break;
   }
 
-  // check if all processes finished without an error
+  // check if all processes finished the loop
   if (world.rank() == 0) {
-    if (monitor.emergency_occured()) {
-      std::cout << "Oh no! An error occurred somewhere.\n";
+    if (monitor.some_event_occurred()) {
+      std::cout << "Oh no! An event occurred somewhere and loop has not been finished on all processes.\n";
     } else {
-      std::cout << "No worries, all processes finished without an error.\n";
+      std::cout << "No worries, all processes have finished the loop.\n";
     }
   }
 }
@@ -54,24 +54,24 @@ int main(int argc, char *argv[]) {
 Output (running with `-n 12`):
 
 ```
-Processor 3: Emergency stop requested.
-Processor 3: After 0 steps an emergency stop has been received.
-Processor 2: After 5950 steps an emergency stop has been received.
-Processor 4: After 10475 steps an emergency stop has been received.
-Processor 5: After 7379 steps an emergency stop has been received.
-Processor 6: After 8366 steps an emergency stop has been received.
-Processor 7: After 1302 steps an emergency stop has been received.
-Processor 8: After 1155 steps an emergency stop has been received.
-Processor 9: After 14445 steps an emergency stop has been received.
-Processor 11: After 9287 steps an emergency stop has been received.
-Processor 0: After 0 steps an emergency stop has been received.
-Processor 1: After 7443 steps an emergency stop has been received.
-Processor 10: After 1321 steps an emergency stop has been received.
-Oh no! An error occurred somewhere.
+Processor 3: Local event reported.
+Processor 3: After 0 steps an event has been communicated.
+Processor 4: After 8428 steps an event has been communicated.
+Processor 0: After 0 steps an event has been communicated.
+Processor 8: After 10723 steps an event has been communicated.
+Processor 5: After 10426 steps an event has been communicated.
+Processor 6: After 12172 steps an event has been communicated.
+Processor 7: After 9014 steps an event has been communicated.
+Processor 1: After 400 steps an event has been communicated.
+Processor 2: After 1646 steps an event has been communicated.
+Processor 11: After 12637 steps an event has been communicated.
+Processor 10: After 9120 steps an event has been communicated.
+Processor 9: After 1 steps an event has been communicated.
+Oh no! An event occurred somewhere and the loop has not been finished on all processes.
 ```
 
 Output (running with `-n 3`):
 
 ```
-No worries, all processes finished without an error.
+No worries, all processes have finished the loop.
 ```

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -54,10 +54,10 @@
  */
 
 /**
- * @defgroup err_handling Error handling
- * @brief Communicate and handle errors across multiple processes.
+ * @defgroup event_handling Event handling
+ * @brief Communicate and handle events across multiple processes.
  *
- * @details A typical use case for the mpi::monitor class could be:
+ * @details A typical use case for the mpi::monitor class could be to monitor and communicate exceptions:
  *
  * @code{.cpp}
  * // initialize monitor
@@ -65,19 +65,19 @@
  * ...
  *
  * // loop as long as everything is fine
- * while (!monitor.emergency_occured()) {
+ * while (!monitor.some_event_occurred()) {
  *   try {
  *      // do some work
  *      ...
  *   } catch (my_exception const &e) {
- *     // send an emergency stop request
- *     monitor.request_emergency_stop();
+ *     // report an exception
+ *     monitor.report_local_event();
  *   }
  * }
  *
- * // finalize communications and check if the computation finished due to an error
+ * // finalize communications and check if the computation finished due to an exception
  * monitor.finalize_communications();
- * if (!monitor.emergency_occured()) {
+ * if (!monitor.some_event_occurred()) {
  *    // do some clean up and maybe stop the program
  *    ...
  * }

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -65,7 +65,7 @@
  * ...
  *
  * // loop as long as everything is fine
- * while (!monitor.some_event_occurred()) {
+ * while (!monitor.event_on_any_rank()) {
  *   try {
  *      // do some work
  *      ...
@@ -77,7 +77,7 @@
  *
  * // finalize communications and check if the computation finished due to an exception
  * monitor.finalize_communications();
- * if (!monitor.some_event_occurred()) {
+ * if (!monitor.event_on_any_rank()) {
  *    // do some clean up and maybe stop the program
  *    ...
  * }

--- a/test/c++/mpi_monitor.cpp
+++ b/test/c++/mpi_monitor.cpp
@@ -168,11 +168,9 @@ TEST(MPI, MultipleMonitors) {
   // test multiple monitors
   usleep(1000);
   mpi::communicator world;
-  auto dup = world.duplicate();
-  auto dupdup = world.duplicate();
   mpi::monitor monitor1{world};
-  mpi::monitor monitor2{dup};
-  mpi::monitor monitor3{dupdup};
+  mpi::monitor monitor2{world};
+  mpi::monitor monitor3{world};
   if (world.rank() == 0) {
     monitor3.report_local_event();
   }
@@ -187,8 +185,6 @@ TEST(MPI, MultipleMonitors) {
   EXPECT_TRUE(monitor3.event_on_any_rank());
   if (world.size() == 1) EXPECT_TRUE(monitor3.event_on_all_ranks());
   else EXPECT_FALSE(monitor3.event_on_all_ranks());
-  dup.free();
-  dupdup.free();
   usleep(1000);
 }
 

--- a/test/c++/mpi_monitor.cpp
+++ b/test/c++/mpi_monitor.cpp
@@ -42,7 +42,7 @@ bool test_monitor(mpi::communicator c, int fastest_node, std::vector<int> rank_r
   std::cerr << "Node " << c.rank() << ": sleeptime " << sleeptime << std::endl;
 
   mpi::monitor monitor{c};
-  auto events_occurred = [all_events, &monitor]() { return all_events ? monitor.all_events_occurred() : monitor.some_event_occurred(); };
+  auto events_occurred = [all_events, &monitor]() { return all_events ? monitor.event_on_all_ranks() : monitor.event_on_any_rank(); };
 
   for (int i = 0; (!events_occurred()) and (i < niter); ++i) {
     usleep(sleeptime);
@@ -180,13 +180,13 @@ TEST(MPI, MultipleMonitors) {
   monitor1.finalize_communications();
   monitor2.finalize_communications();
   monitor3.finalize_communications();
-  EXPECT_FALSE(monitor1.some_event_occurred());
-  EXPECT_FALSE(monitor1.all_events_occurred());
-  EXPECT_TRUE(monitor2.some_event_occurred());
-  EXPECT_TRUE(monitor2.all_events_occurred());
-  EXPECT_TRUE(monitor3.some_event_occurred());
-  if (world.size() == 1) EXPECT_TRUE(monitor3.all_events_occurred());
-  else EXPECT_FALSE(monitor3.all_events_occurred());
+  EXPECT_FALSE(monitor1.event_on_any_rank());
+  EXPECT_FALSE(monitor1.event_on_all_ranks());
+  EXPECT_TRUE(monitor2.event_on_any_rank());
+  EXPECT_TRUE(monitor2.event_on_all_ranks());
+  EXPECT_TRUE(monitor3.event_on_any_rank());
+  if (world.size() == 1) EXPECT_TRUE(monitor3.event_on_all_ranks());
+  else EXPECT_FALSE(monitor3.event_on_all_ranks());
   dup.free();
   dupdup.free();
   usleep(1000);

--- a/test/c++/mpi_monitor.cpp
+++ b/test/c++/mpi_monitor.cpp
@@ -16,73 +16,81 @@
 
 #include <gtest/gtest.h>
 #include <mpi/monitor.hpp>
+#include <mpi.h>
 
 #include <algorithm>
 #include <iostream>
+#include <numeric>
 #include <vector>
 #include <unistd.h>
 
 // in micro second = 1 milli second
 const int delta_tau_sleep = 1000;
 
-// Monitor all nodes while some of them might fail.
+// Monitor all nodes while some of them might report an event.
 //
-// c: MPI communicator
-// fastest_node: rank of the fastest node
-// rank_failing: ranks of the nodes that will fail
-// iteration_failure: iteration at which the nodes will fail
-bool test(mpi::communicator c, int fastest_node, std::vector<int> rank_failing, int iteration_failure = 3) {
+// c: MPI communicator.
+// fastest_node: Rank of the fastest node.
+// rank_reporting: Ranks of the nodes that will report an event.
+// all_events: If true, the all_events_occurred() function will be used instead of some_event_occurred().
+// iteration_event: Iteration at which the nodes will report an event.
+bool test_monitor(mpi::communicator c, int fastest_node, std::vector<int> rank_reporting, bool all_events = false, int iteration_event = 3) {
   const int niter = 10;
   const int size  = c.size();
   int sleeptime   = delta_tau_sleep * (((c.rank() - fastest_node + size) % size) + 1);
-  bool will_fail  = std::any_of(rank_failing.cbegin(), rank_failing.cend(), [&c](int i) { return i == c.rank(); });
+  bool will_fail  = std::any_of(rank_reporting.cbegin(), rank_reporting.cend(), [&c](int i) { return i == c.rank(); });
   std::cerr << "Node " << c.rank() << ": sleeptime " << sleeptime << std::endl;
 
   mpi::monitor monitor{c};
+  auto events_occurred = [all_events, &monitor]() { return all_events ? monitor.all_events_occurred() : monitor.some_event_occurred(); };
 
-  for (int i = 0; (!monitor.emergency_occured()) and (i < niter); ++i) {
+  for (int i = 0; (!events_occurred()) and (i < niter); ++i) {
     usleep(sleeptime);
-    std::cerr << "Node " << c.rank() << "is in iteration " << i << std::endl;
-    if (will_fail and (i >= iteration_failure)) {
+    std::cerr << "Node " << c.rank() << " is in iteration " << i << std::endl;
+    if (will_fail and (i >= iteration_event)) {
       std::cerr << "Node " << c.rank() << " is failing" << std::endl;
-      monitor.request_emergency_stop();
-      monitor.request_emergency_stop(); // 2nd call should not resend MPI message
+      monitor.report_local_event();
+      monitor.report_local_event(); // 2nd call should not resend MPI message
     }
     if (i == niter - 1) { std::cerr << "Node " << c.rank() << " has done all tasks" << std::endl; }
   }
 
   monitor.finalize_communications();
   std::cerr << "Ending on node " << c.rank() << std::endl;
-  return not monitor.emergency_occured();
+  return not events_occurred();
 }
 
-TEST(MPI, MonitorNoFailure) {
-  // no failure
+TEST(MPI, MonitorNoEvent) {
+  // no event
   usleep(1000);
   mpi::communicator world;
   for (int i = 0; i < world.size(); ++i) {
     world.barrier();
     if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
-    EXPECT_TRUE(test(world, i, {}));
+    EXPECT_TRUE(test_monitor(world, i, {}));
+    world.barrier();
+    EXPECT_TRUE(test_monitor(world, i, {}, true));
     world.barrier();
   }
 }
 
-TEST(MPI, MonitorOneFailureOnRoot) {
-  // root node fails
+TEST(MPI, MonitorOneEventOnRoot) {
+  // one event on root node
   usleep(1000);
   mpi::communicator world;
   for (int i = 0; i < world.size(); ++i) {
     world.barrier();
     if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
-    EXPECT_EQ(test(world, i, {0}), false);
+    EXPECT_EQ(test_monitor(world, i, {0}), false);
+    world.barrier();
+    EXPECT_EQ(test_monitor(world, i, {0}, true), world.size() > 1);
     world.barrier();
   }
   usleep(1000);
 }
 
-TEST(MPI, MonitorOneFailureOnNonRoot) {
-  // one non-root node fails
+TEST(MPI, MonitorOneEventOnNonRoot) {
+  // one event on non-root node
   usleep(1000);
   mpi::communicator world;
   if (world.size() < 2) {
@@ -92,15 +100,17 @@ TEST(MPI, MonitorOneFailureOnNonRoot) {
       world.barrier();
       if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
       bool has_failure = (world.size() > 1 ? false : true); // No failure if only rank 0 exists
-      EXPECT_EQ(test(world, i, {1}), has_failure);
+      EXPECT_EQ(test_monitor(world, i, {1}), has_failure);
+      world.barrier();
+      EXPECT_EQ(test_monitor(world, i, {1}, true), world.size() > 1);
       world.barrier();
     }
   }
   usleep(1000);
 }
 
-TEST(MPI, MonitorTwoFailuresWithRoot) {
-  // two nodes fail including the root process
+TEST(MPI, MonitorTwoEventsWithRoot) {
+  // two events on nodes including the root process
   usleep(1000);
   mpi::communicator world;
   if (world.size() < 2) {
@@ -109,15 +119,17 @@ TEST(MPI, MonitorTwoFailuresWithRoot) {
     for (int i = 0; i < world.size(); ++i) {
       world.barrier();
       if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
-      EXPECT_EQ(test(world, i, {0, 1}), false);
+      EXPECT_EQ(test_monitor(world, i, {0, 1}), false);
+      world.barrier();
+      EXPECT_EQ(test_monitor(world, i, {0, 1}, true), world.size() > 2);
       world.barrier();
     }
   }
   usleep(1000);
 }
 
-TEST(MPI, MonitorTwoFailuresWithoutRoot) {
-  // two nodes fail excluding the root process
+TEST(MPI, MonitorTwoEventsWithoutRoot) {
+  // two events on nodes excluding the root process
   usleep(1000);
   mpi::communicator world;
   if (world.size() < 3) {
@@ -126,10 +138,57 @@ TEST(MPI, MonitorTwoFailuresWithoutRoot) {
     for (int i = 0; i < world.size(); ++i) {
       world.barrier();
       if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
-      EXPECT_EQ(test(world, i, {1, 2}), false);
+      EXPECT_EQ(test_monitor(world, i, {1, 2}), false);
+      world.barrier();
+      EXPECT_EQ(test_monitor(world, i, {1, 2}, true), world.size() > 2);
       world.barrier();
     }
   }
+  usleep(1000);
+}
+
+TEST(MPI, MonitorAllEvents) {
+  // events on all nodes
+  usleep(1000);
+  mpi::communicator world;
+  std::vector<int> rank_reporting(world.size());
+  std::iota(rank_reporting.begin(), rank_reporting.end(), 0);
+  for (int i = 0; i < world.size(); ++i) {
+    world.barrier();
+    if (world.rank() == 0) std::cerr << "***\nNode " << i << " is the fastest" << std::endl;
+    EXPECT_FALSE(test_monitor(world, i, rank_reporting));
+    world.barrier();
+    EXPECT_FALSE(test_monitor(world, i, rank_reporting, true));
+    world.barrier();
+  }
+  usleep(1000);
+}
+
+TEST(MPI, MultipleMonitors) {
+  // test multiple monitors
+  usleep(1000);
+  mpi::communicator world;
+  auto dup = world.duplicate();
+  auto dupdup = world.duplicate();
+  mpi::monitor monitor1{world};
+  mpi::monitor monitor2{dup};
+  mpi::monitor monitor3{dupdup};
+  if (world.rank() == 0) {
+    monitor3.report_local_event();
+  }
+  monitor2.report_local_event();
+  monitor1.finalize_communications();
+  monitor2.finalize_communications();
+  monitor3.finalize_communications();
+  EXPECT_FALSE(monitor1.some_event_occurred());
+  EXPECT_FALSE(monitor1.all_events_occurred());
+  EXPECT_TRUE(monitor2.some_event_occurred());
+  EXPECT_TRUE(monitor2.all_events_occurred());
+  EXPECT_TRUE(monitor3.some_event_occurred());
+  if (world.size() == 1) EXPECT_TRUE(monitor3.all_events_occurred());
+  else EXPECT_FALSE(monitor3.all_events_occurred());
+  dup.free();
+  dupdup.free();
   usleep(1000);
 }
 


### PR DESCRIPTION
- added a `duplicate` and a `free` function to the `mpi::communicator` class
- generalized the `mpi::monitor` class to handle general events instead of errors
  - renamed member functions
  - allow to check if at least one event has occurred on some process (`some_event_occurred()`) or if an event has occurred on all processes (`all_events_occurred()`)
  - use the given communicator instead of `MPI_COMM_WORLD`
  - make `root` a member variable which defaults to 0