### PR TITLE
Add collective communications for general ranges

### DIFF
--- a/c++/mpi/array.hpp
+++ b/c++/mpi/array.hpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Olivier Parcollet, Nils Wentzell
+
+/**
+ * @file
+ * @brief Provides an MPI broadcast, reduce, scatter and gather for std::vector.
+ */
+
+#pragma once
+
+#include "./mpi.hpp"
+#include "./ranges.hpp"
+
+#include <mpi.h>
+
+#include <array>
+#include <cstddef>
+
+namespace mpi {
+
+  /**
+   * @addtogroup coll_comm
+   * @{
+   */
+
+  /**
+   * @brief Implementation of an MPI broadcast for a std::arr.
+   *
+   * @details It simply calls mpi::broadcast_range with the input array.
+   *
+   * @tparam T Value type of the array.
+   * @tparam N Size of the array.
+   * @param arr std::array to broadcast.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   */
+  template <typename T, std::size_t N> void mpi_broadcast(std::array<T, N> &arr, communicator c = {}, int root = 0) { broadcast_range(arr, c, root); }
+
+  /**
+   * @brief Implementation of an in-place MPI reduce for a std::array.
+   *
+   * @details It simply calls mpi::reduce_in_place_range with the given input array.
+   *
+   * @tparam T Value type of the array.
+   * @tparam N Size of the array.
+   * @param arr std::array to reduce.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param all Should all processes receive the result of the reduction.
+   * @param op `MPI_Op` used in the reduction.
+   */
+  template <typename T, std::size_t N>
+  void mpi_reduce_in_place(std::array<T, N> &arr, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    reduce_in_place_range(arr, c, root, all, op);
+  }
+
+  /**
+   * @brief Implementation of an MPI reduce for a std::array.
+   *
+   * @details It simply calls mpi::reduce_range with the given input array and an empty array of the same size.
+   *
+   * @tparam T Value type of the array.
+   * @tparam N Size of the array.
+   * @param arr std::array to reduce.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param all Should all processes receive the result of the reduction.
+   * @param op `MPI_Op` used in the reduction.
+   * @return std::array containing the result of each individual reduction.
+   */
+  template <typename T, std::size_t N>
+  std::array<regular_t<T>, N> mpi_reduce(std::array<T, N> const &arr, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    std::array<regular_t<T>, N> res{};
+    reduce_range(arr, res, c, root, all, op);
+    return res;
+  }
+
+  /** @} */
+
+} // namespace mpi

--- a/c++/mpi/array.hpp
+++ b/c++/mpi/array.hpp
@@ -21,8 +21,9 @@
 
 #pragma once
 
-#include "./mpi.hpp"
+#include "./communicator.hpp"
 #include "./ranges.hpp"
+#include "./utils.hpp"
 
 #include <mpi.h>
 

--- a/c++/mpi/array.hpp
+++ b/c++/mpi/array.hpp
@@ -83,7 +83,7 @@ namespace mpi {
    * @return std::array containing the result of each individual reduction.
    */
   template <typename T, std::size_t N>
-  std::array<regular_t<T>, N> mpi_reduce(std::array<T, N> const &arr, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+  auto mpi_reduce(std::array<T, N> const &arr, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     std::array<regular_t<T>, N> res{};
     reduce_range(arr, res, c, root, all, op);
     return res;

--- a/c++/mpi/monitor.hpp
+++ b/c++/mpi/monitor.hpp
@@ -21,8 +21,8 @@
 
 #pragma once
 
+#include "./communicator.hpp"
 #include "./macros.hpp"
-#include "./mpi.hpp"
 #include "./utils.hpp"
 
 #include <mpi.h>

--- a/c++/mpi/mpi.hpp
+++ b/c++/mpi/mpi.hpp
@@ -21,14 +21,20 @@
 
 #pragma once
 
+#include "./array.hpp"
 #include "./chunk.hpp"
 #include "./communicator.hpp"
 #include "./datatypes.hpp"
 #include "./environment.hpp"
 #include "./generic_communication.hpp"
 #include "./lazy.hpp"
+#include "./monitor.hpp"
 #include "./operators.hpp"
+#include "./pair.hpp"
+#include "./ranges.hpp"
+#include "./string.hpp"
 #include "./utils.hpp"
+#include "./vector.hpp"
 
 namespace mpi {
 

--- a/c++/mpi/ranges.hpp
+++ b/c++/mpi/ranges.hpp
@@ -1,0 +1,461 @@
+// Copyright (c) 2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Alexander Hampel, Olivier Parcollet, Nils Wentzell
+
+/**
+ * @file
+ * @brief Provides an MPI broadcast, reduce, scatter and gather for contiguous ranges.
+ */
+
+#pragma once
+
+#include "./macros.hpp"
+#include "./mpi.hpp"
+
+#include <itertools/itertools.hpp>
+
+#include <algorithm>
+#include <ranges>
+#include <stdexcept>
+#include <vector>
+
+namespace mpi {
+
+  /**
+   * @brief A concept that checks if a range type is contiguous and sized.
+   * @tparam R Range type.
+   */
+  template <typename R>
+  concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges::sized_range<R>;
+
+  /**
+   * @brief Implementation of an MPI broadcast for an mpi::contiguous_sized_range object.
+   *
+   * @details If mpi::has_mpi_type is true for the value type of the range, then the range is broadcasted using a simple
+   * `MPI_Bcast`. Otherwise, the generic mpi::broadcast is called for each element of the range.
+   *
+   * It throws an exception in case a call to the MPI C library fails and it expects that the sizes of the ranges are
+   * equal across all processes.
+   *
+   * If the ranges are empty or if mpi::has_env is false or if the communicator size is < 2, it does nothing.
+   *
+   * @note It is recommended to use the generic mpi::broadcast for supported types, e.g. `std::vector`, `std::array` or
+   * `std::string`. It is the user's responsibility to ensure that ranges have the correct sizes.
+   *
+   * @code{.cpp}
+   * // create a vector on all ranks
+   * auto vec = std::vector<int>(5);
+   *
+   * if (comm.rank() == 0) {
+   *   // on rank 0, initialize the vector and broadcast the first 3 elements
+   *   vec = {1, 2, 3, 0, 0};
+   *   mpi::broadcast_range(std::span{vec.data(), 3}, comm);
+   * } else {
+   *   // on other ranks, broadcast to the last 3 elements of the vector
+   *   mpi::broadcast_range(std::span{vec.data() + 2, 3}, comm);
+   * }
+   *
+   * // output result
+   * for (auto x : vec) std::cout << x << " ";
+   * std::cout << std::endl;
+   * @endcode
+   *
+   * Output (with 4 processes):
+   *
+   * ```
+   * 1 2 3 0 0
+   * 0 0 1 2 3
+   * 0 0 1 2 3
+   * 0 0 1 2 3
+   * ```
+   *
+   * @tparam R mpi::contiguous_sized_range type.
+   * @param rg Range to broadcast.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   */
+  template <contiguous_sized_range R> void broadcast_range(R &&rg, communicator c = {}, int root = 0) {
+    // check the sizes of all ranges
+    using value_t   = std::ranges::range_value_t<R>;
+    auto const size = std::ranges::size(rg);
+    EXPECTS_WITH_MESSAGE(all_equal(size, c), "Range sizes are not equal across all processes in mpi::broadcast_range");
+
+    // do nothing if the range is empty, if MPI is not initialized or if the communicator size is < 2
+    if (size == 0 || !has_env || c.size() < 2) return;
+
+    // broadcast the range
+    if constexpr (has_mpi_type<value_t>)
+      // make an MPI C library call for MPI compatible value types
+      check_mpi_call(MPI_Bcast(std::ranges::data(rg), size, mpi_type<value_t>::get(), root, c.get()), "MPI_Bcast");
+    else
+      // otherwise call the specialized mpi_broadcast for each element
+      for (auto &val : rg) broadcast(val, c, root);
+  }
+
+  /**
+   * @brief Implementation of an in-place MPI reduce for an mpi::contiguous_sized_range object.
+   *
+   * @details If mpi::has_mpi_type is true for the value type of the range, then the range is reduced using a simple
+   * `MPI_Reduce` or `MPI_Allreduce` with `MPI_IN_PLACE`. Otherwise, the specialized `mpi_reduce_in_place` is called
+   * for each element in the range.
+   *
+   * It throws an exception in case a call to the MPI C library fails and it expects that the sizes of the ranges are
+   * equal across all processes.
+   *
+   * If the ranges are empty or if mpi::has_env is false or if the communicator size is < 2, it does nothing.
+   *
+   * @note It is recommended to use the generic mpi::reduce_in_place and mpi::all_reduce_in_place for supported types,
+   * e.g. `std::vector` or `std::array`. It is the user's responsibility to ensure that ranges have the correct sizes.
+   *
+   * @code{.cpp}
+   * // create a vector on all ranks
+   * auto vec = std::vector<int>{0, 1, 2, 3, 4};
+   *
+   * // in-place reduce the middle elements only on rank 0
+   * mpi::reduce_in_place_range(std::span{vec.data() + 1, 3}, comm);
+   *
+   * // output result
+   * for (auto x : vec) std::cout << x << " ";
+   * std::cout << std::endl;
+   * @endcode
+   *
+   * Output (with 4 processes):
+   *
+   * ```
+   * 0 1 2 3 4
+   * 0 1 2 3 4
+   * 0 1 2 3 4
+   * 0 4 8 12 4
+   * ```
+   *
+   * @tparam R mpi::contiguous_sized_range type.
+   * @param rg Range to reduce.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param all Should all processes receive the result of the reduction.
+   * @param op `MPI_Op` used in the reduction.
+   */
+  template <contiguous_sized_range R> void reduce_in_place_range(R &&rg, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    // check the sizes of all ranges
+    using value_t   = std::ranges::range_value_t<R>;
+    auto const size = std::ranges::size(rg);
+    EXPECTS_WITH_MESSAGE(all_equal(size, c), "Range sizes are not equal across all processes in mpi::reduce_in_place_range");
+
+    // do nothing if the range is empty, if MPI is not initialized or if the communicator size is < 2
+    if (size == 0 || !has_env || c.size() < 2) return;
+
+    // reduce the ranges
+    if constexpr (has_mpi_type<value_t>) {
+      // make an MPI C library call for MPI compatible value types
+      auto data = std::ranges::data(rg);
+      if (!all)
+        check_mpi_call(MPI_Reduce((c.rank() == root ? MPI_IN_PLACE : data), data, size, mpi_type<value_t>::get(), op, root, c.get()), "MPI_Reduce");
+      else
+        check_mpi_call(MPI_Allreduce(MPI_IN_PLACE, data, size, mpi_type<value_t>::get(), op, c.get()), "MPI_Allreduce");
+    } else {
+      // otherwise call the specialized mpi_reduce_in_place for each element
+      for (auto &val : rg) mpi_reduce_in_place(val, c, root, all, op);
+    }
+  }
+
+  /**
+   * @brief Implementation of an MPI reduce for an mpi::contiguous_sized_range.
+   *
+   * @details If mpi::has_mpi_type is true for the value type of the range, then the range is reduced using a simple
+   * `MPI_Reduce` or `MPI_Allreduce`. Otherwise, the specialized `mpi_reduce` is called for each element in the range.
+   *
+   * It throws an exception in case a call to the MPI C library fails and it expects that the sizes of the input ranges
+   * are equal across all processes and that they are equal to the size of the output range on receiving processes.
+   *
+   * If the input ranges are empty, it does nothing. If mpi::has_env is false or if the communicator size is < 2, it
+   * simply copies the input range to the output range.
+   *
+   * @note It is recommended to use the generic mpi::reduce and mpi::all_reduce for supported types, e.g. `std::vector`
+   * or `std::array`. It is the user's responsibility to ensure that ranges have the correct sizes.
+   *
+   * @code{.cpp}
+   * // create input and output vectors on all ranks
+   * auto in_vec = std::vector<int>{0, 1, 2, 3, 4};
+   * auto out_vec = std::vector<int>(in_vec.size(), 0);
+   *
+   * // allreduce the middle elements of the input vector to the last elements of the output vector
+   * mpi::reduce_range(std::span{in_vec.data() + 1, 3}, std::span{out_vec.data() + 2, 3}, comm, 0, true);
+   *
+   * // output result
+   * for (auto x : out_vec) std::cout << x << " ";
+   * std::cout << std::endl;
+   * @endcode
+   *
+   * Output (with 4 processes):
+   *
+   * ```
+   * 0 0 4 8 12
+   * 0 0 4 8 12
+   * 0 0 4 8 12
+   * 0 0 4 8 12
+   * ```
+   *
+   * @tparam R1 mpi::contiguous_sized_range type.
+   * @tparam R2 mpi::contiguous_sized_range type.
+   * @param in_rg Range to reduce.
+   * @param out_rg Range to reduce into.
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param all Should all processes receive the result of the reduction.
+   * @param op `MPI_Op` used in the reduction.
+   */
+  template <contiguous_sized_range R1, contiguous_sized_range R2>
+  void reduce_range(R1 &&in_rg, R2 &&out_rg, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    // check input and output ranges
+    auto const in_size = std::ranges::size(in_rg);
+    EXPECTS_WITH_MESSAGE(all_equal(in_size, c), "Input range sizes are not equal across all processes in mpi::reduce_range");
+    if (c.rank() == root || all) {
+      EXPECTS_WITH_MESSAGE(in_size == std::ranges::size(out_rg), "Input and output range sizes are not equal in mpi::reduce_range");
+    }
+
+    // do nothing if the input range is empty
+    if (in_size == 0) return;
+
+    // simply copy if there is no active MPI environment or if the communicator size is < 2
+    if (!has_env || c.size() < 2) {
+      std::ranges::copy(std::forward<R1>(in_rg), std::ranges::data(out_rg));
+      return;
+    }
+
+    // reduce the ranges
+    using in_value_t  = std::ranges::range_value_t<R1>;
+    using out_value_t = std::ranges::range_value_t<R2>;
+    if constexpr (has_mpi_type<in_value_t> && std::same_as<in_value_t, out_value_t>) {
+      // make an MPI C library call for MPI compatible value types
+      auto const in_data = std::ranges::data(in_rg);
+      auto out_data      = std::ranges::data(out_rg);
+      if (!all)
+        check_mpi_call(MPI_Reduce(in_data, out_data, in_size, mpi_type<in_value_t>::get(), op, root, c.get()), "MPI_Reduce");
+      else
+        check_mpi_call(MPI_Allreduce(in_data, out_data, in_size, mpi_type<in_value_t>::get(), op, c.get()), "MPI_Allreduce");
+    } else {
+      // otherwise call the specialized mpi_reduce for each element
+      // the size of the output range is arbitrary on non-recieving ranks, so we cannot use transform on them
+      if (c.rank() == root || all)
+        std::ranges::transform(std::forward<R1>(in_rg), std::ranges::data(out_rg), [&](auto const &val) { return reduce(val, c, root, all, op); });
+      else
+        // the assignment is needed in case a lazy object is returned
+        std::ranges::for_each(std::forward<R1>(in_rg), [&](auto const &val) { [[maybe_unused]] out_value_t ignore = reduce(val, c, root, all, op); });
+    }
+  }
+
+  /**
+   * @brief Implementation of an MPI scatter for an mpi::contiguous_sized_range.
+   *
+   * @details If mpi::has_mpi_type is true for the value type of the range, then the range is scattered as evenly as
+   * possible across the processes in the communicator using a simple `MPI_Scatterv`. Otherwise an exception is thrown.
+   *
+   * The user can specify a chunk size which is used to divide the input range into chunks of the specified size. The
+   * number of chunks are then distributed evenly across the processes in the communicator. The size of the input range
+   * is required to be a multiple of the given chunk size, otherwise an exception is thrown.
+   *
+   * It throws an exception in case a call to the MPI C library fails and it expects that the output ranges have the
+   * correct size and that they add up to the size of the input range on the root process.
+   *
+   * If the input range is empty on root, it does nothing. If mpi::has_env is false or if the communicator size is < 2,
+   * it simply copies the input range to the output range.
+   *
+   * @note It is recommended to use the generic mpi::scatter for supported types, e.g. `std::vector`. It is the user's
+   * responsibility to ensure that the ranges have the correct sizes (mpi::chunk_length can be useful to do that).
+   *
+   * @code{.cpp}
+   * // create input and output vectors on all ranks
+   * auto in_vec = std::vector<int>{};
+   * if (comm.rank() == 0) in_vec = {0, 1, 2, 3, 4, 5, 6, 7};
+   * auto out_vec = std::vector<int>(mpi::chunk_length(5, comm.size(), comm.rank()), 0);
+   *
+   * // scatter the middle elements of the input vector from rank 0 to all ranks
+   * mpi::scatter_range(std::span{in_vec.data() + 1, 5}, out_vec, 5, comm);
+   *
+   * // output result
+   * for (auto x : out_vec) std::cout << x << " ";
+   * std::cout << std::endl;
+   * @endcode
+   *
+   * Output (with 2 processes):
+   *
+   * ```
+   * 4 5
+   * 1 2 3
+   * ```
+   *
+   * @tparam R1 mpi::contiguous_sized_range type.
+   * @tparam R2 mpi::contiguous_sized_range type.
+   * @param in_rg Range to scatter.
+   * @param out_rg Range to scatter into.
+   * @param in_size Size of the input range on root (must also be given on non-root ranks).
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param chunk_size Size of the chunks to scatter.
+   */
+  template <contiguous_sized_range R1, contiguous_sized_range R2>
+    requires(std::same_as<std::ranges::range_value_t<R1>, std::ranges::range_value_t<R2>>)
+  void scatter_range(R1 &&in_rg, R2 &&out_rg, long in_size, communicator c = {}, int root = 0, long chunk_size = 1) {
+    // check the sizes of the input and output ranges
+    if (c.rank() == root) {
+      EXPECTS_WITH_MESSAGE(in_size == std::ranges::size(in_rg), "Input range size not equal to provided size in mpi::scatter_range");
+    }
+    EXPECTS_WITH_MESSAGE(in_size == all_reduce(std::ranges::size(out_rg), c),
+                         "Output range sizes don't add up to input range size in mpi::scatter_range");
+
+    // do nothing if the input range is empty
+    if (in_size == 0) return;
+
+    // simply copy if there is no active MPI environment or if the communicator size is < 2
+    if (!has_env || c.size() < 2) {
+      std::ranges::copy(std::forward<R1>(in_rg), std::ranges::data(out_rg));
+      return;
+    }
+
+    // check the size of the output range
+    int recvcount = static_cast<int>(chunk_length(in_size, c.size(), c.rank(), chunk_size));
+    EXPECTS_WITH_MESSAGE(recvcount == std::ranges::size(out_rg), "Output range size is incorrect in mpi::scatter_range");
+
+    // prepare arguments for the MPI call
+    auto sendcounts = std::vector<int>(c.size());
+    auto displs     = std::vector<int>(c.size() + 1, 0);
+    for (int i = 0; i < c.size(); ++i) {
+      sendcounts[i] = static_cast<int>(chunk_length(in_size, c.size(), i, chunk_size));
+      displs[i + 1] = sendcounts[i] + displs[i];
+    }
+
+    // scatter the range
+    using in_value_t  = std::ranges::range_value_t<R1>;
+    using out_value_t = std::ranges::range_value_t<R2>;
+    if constexpr (has_mpi_type<in_value_t> && has_mpi_type<out_value_t>) {
+      // make an MPI C library call for MPI compatible value types
+      auto const in_data = std::ranges::data(in_rg);
+      auto out_data      = std::ranges::data(out_rg);
+      check_mpi_call(MPI_Scatterv(in_data, sendcounts.data(), displs.data(), mpi_type<in_value_t>::get(), out_data, recvcount,
+                                  mpi_type<out_value_t>::get(), root, c.get()),
+                     "MPI_Scatterv");
+    } else {
+      // otherwise throw an exception
+      throw std::runtime_error{"Error in mpi::scatter_range: Types with no corresponding datatype can only be all-gathered"};
+    }
+  }
+
+  /**
+   * @brief Implementation of an MPI gather for an mpi::contiguous_sized_range.
+   *
+   * @details If mpi::has_mpi_type is true for the value type of the input ranges, then the ranges are gathered using a
+   * simple `MPI_Gatherv` or `MPI_Allgatherv`. Otherwise, each process broadcasts its elements to all other processes
+   * which implies that `all == true` is required in this case.
+   *
+   * It throws an exception in case a call to the MPI C library fails and it expects that the sizes of the input ranges
+   * add up to the given size of the output range and that the output ranges have the correct size on receiving
+   * processes.
+   *
+   * If the input ranges are all empty, it does nothing. If mpi::has_env is false or if the communicator size is < 2, it
+   * simply copies the input range to the output range.
+   *
+   * @note It is recommended to use the generic mpi::gather for supported types, e.g. `std::vector` and `std::string`.
+   * It is the user's responsibility to ensure that the ranges have the correct sizes.
+   *
+   * @code{.cpp}
+   * // create input and output vectors on all ranks
+   * auto in_vec  = std::vector<int>{0, 1, 2, 3, 4};
+   * auto out_vec = std::vector<int>(3 * comm.size(), 0);
+   *
+   * // gather the middle elements of the input vectors from all ranks on rank 0
+   * mpi::gather_range(std::span{in_vec.data() + 1, 3}, out_vec, 3 * comm.size(), comm);
+   *
+   * // output result
+   * for (auto x : out_vec) std::cout << x << " ";
+   * std::cout << std::endl;
+   * @endcode
+   *
+   * Output (with 2 processes):
+   *
+   * ```
+   * 0 0 0 0 0 0 0 0 0 0 0 0
+   * 0 0 0 0 0 0 0 0 0 0 0 0
+   * 0 0 0 0 0 0 0 0 0 0 0 0
+   * 1 2 3 1 2 3 1 2 3 1 2 3
+   * ```
+   *
+   * @tparam R1 mpi::contiguous_sized_range type.
+   * @tparam R2 mpi::contiguous_sized_range type.
+   * @param in_rg Range to gather.
+   * @param out_rg Range to gather into.
+   * @param out_size Size of the output range on receiving processes (must also be given on non-receiving ranks).
+   * @param c mpi::communicator.
+   * @param root Rank of the root process.
+   * @param all Should all processes receive the result of the reduction.
+   */
+  template <contiguous_sized_range R1, contiguous_sized_range R2>
+  void gather_range(R1 &&in_rg, R2 &&out_rg, long out_size, communicator c = {}, int root = 0, bool all = false) {
+    // check the sizes of the input and output ranges
+    auto const in_size = std::ranges::size(in_rg);
+    EXPECTS_WITH_MESSAGE(out_size = all_reduce(in_size, c), "Input range sizes don't add up to output range size in mpi::gather_range");
+    if (c.rank() == root || all) {
+      EXPECTS_WITH_MESSAGE(out_size == std::ranges::size(out_rg), "Output range size is incorrect in mpi::gather_range");
+    }
+
+    // do nothing if the output range is empty
+    if (out_size == 0) return;
+
+    // simply copy if there is no active MPI environment or if the communicator size is < 2
+    if (!has_env || c.size() < 2) {
+      std::ranges::copy(std::forward<R1>(in_rg), std::ranges::data(out_rg));
+      return;
+    }
+
+    // prepare arguments for the MPI call
+    auto recvcounts = std::vector<int>(c.size());
+    auto displs     = std::vector<int>(c.size() + 1, 0);
+    int sendcount   = in_size;
+    if (!all)
+      check_mpi_call(MPI_Gather(&sendcount, 1, mpi_type<int>::get(), recvcounts.data(), 1, mpi_type<int>::get(), root, c.get()), "MPI_Gather");
+    else
+      check_mpi_call(MPI_Allgather(&sendcount, 1, mpi_type<int>::get(), recvcounts.data(), 1, mpi_type<int>::get(), c.get()), "MPI_Allgather");
+    for (int i = 0; i < c.size(); ++i) displs[i + 1] = recvcounts[i] + displs[i];
+
+    // gather the ranges
+    using in_value_t  = std::ranges::range_value_t<R1>;
+    using out_value_t = std::ranges::range_value_t<R2>;
+    if constexpr (has_mpi_type<in_value_t> && has_mpi_type<out_value_t>) {
+      // make an MPI C library call for MPI compatible value types
+      auto const in_data = std::ranges::data(in_rg);
+      auto out_data      = std::ranges::data(out_rg);
+      if (!all)
+        check_mpi_call(MPI_Gatherv(in_data, sendcount, mpi_type<in_value_t>::get(), out_data, recvcounts.data(), displs.data(),
+                                   mpi_type<out_value_t>::get(), root, c.get()),
+                       "MPI_Gatherv");
+      else
+        check_mpi_call(MPI_Allgatherv(in_data, sendcount, mpi_type<in_value_t>::get(), out_data, recvcounts.data(), displs.data(),
+                                      mpi_type<out_value_t>::get(), c.get()),
+                       "MPI_Allgatherv");
+    } else {
+      if (all) {
+        // if all == true, each process broadcasts it elements to all other ranks
+        for (int i = 0; i < c.size(); ++i) {
+          auto view = std::views::drop(out_rg, displs[i]) | std::views::take(displs[i + 1] - displs[i]);
+          if (c.rank() == i) std::ranges::copy(in_rg, std::ranges::begin(view));
+          broadcast_range(view, c, i);
+        }
+      } else {
+        // otherwise throw an exception
+        throw std::runtime_error{"Error in mpi::gather_range: Types with no corresponding datatype can only be all-gathered"};
+      }
+    }
+  }
+
+} // namespace mpi

--- a/c++/mpi/ranges.hpp
+++ b/c++/mpi/ranges.hpp
@@ -21,10 +21,16 @@
 
 #pragma once
 
+#include "./chunk.hpp"
+#include "./communicator.hpp"
+#include "./datatypes.hpp"
+#include "./environment.hpp"
+#include "./generic_communication.hpp"
 #include "./macros.hpp"
-#include "./mpi.hpp"
+#include "./utils.hpp"
 
 #include <itertools/itertools.hpp>
+#include <mpi.h>
 
 #include <algorithm>
 #include <ranges>

--- a/c++/mpi/ranges.hpp
+++ b/c++/mpi/ranges.hpp
@@ -40,11 +40,9 @@
 namespace mpi {
 
   /**
-   * @brief A concept that checks if a range type is contiguous and sized.
-   * @tparam R Range type.
+   * @addtogroup coll_comm
+   * @{
    */
-  template <typename R>
-  concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges::sized_range<R>;
 
   /**
    * @brief Implementation of an MPI broadcast for an mpi::contiguous_sized_range object.
@@ -463,5 +461,7 @@ namespace mpi {
       }
     }
   }
+
+  /** @} */
 
 } // namespace mpi

--- a/c++/mpi/string.hpp
+++ b/c++/mpi/string.hpp
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include "./mpi.hpp"
+#include "./communicator.hpp"
+#include "./generic_communication.hpp"
 #include "./ranges.hpp"
 
 #include <string>

--- a/c++/mpi/string.hpp
+++ b/c++/mpi/string.hpp
@@ -30,7 +30,11 @@
 namespace mpi {
 
   /**
-   * @ingroup coll_comm
+   * @addtogroup coll_comm
+   * @{
+   */
+
+  /**
    * @brief Implementation of an MPI broadcast for a std::string.
    *
    * @details It first broadcasts the size of the string from the root process to all other processes, then resizes the
@@ -65,5 +69,7 @@ namespace mpi {
     gather_range(s, res, len, c, root, all);
     return res;
   }
+
+  /** @} */
 
 } // namespace mpi

--- a/c++/mpi/utils.hpp
+++ b/c++/mpi/utils.hpp
@@ -73,6 +73,13 @@ namespace mpi {
     if (errcode != MPI_SUCCESS) throw std::runtime_error("MPI error " + std::to_string(errcode) + " in MPI routine " + mpi_routine);
   }
 
+  /**
+   * @brief A concept that checks if a range type is contiguous and sized.
+   * @tparam R Range type.
+   */
+  template <typename R>
+  concept contiguous_sized_range = std::ranges::contiguous_range<R> && std::ranges::sized_range<R>;
+
   /** @} */
 
 } // namespace mpi

--- a/c++/mpi/utils.hpp
+++ b/c++/mpi/utils.hpp
@@ -33,6 +33,27 @@ namespace mpi {
    * @{
    */
 
+  namespace detail {
+
+    // Helper struct to get the regular type of a type.
+    template <typename T, typename Enable = void> struct _regular {
+      using type = T;
+    };
+
+    // Spezialization of _regular for types with a `regular_type` type alias.
+    template <typename T> struct _regular<T, std::void_t<typename T::regular_type>> {
+      using type = typename T::regular_type;
+    };
+
+  } // namespace detail
+
+  /**
+   * @ingroup utilities
+   * @brief Type trait to get the regular type of a type.
+   * @tparam T Type to check.
+   */
+  template <typename T> using regular_t = typename detail::_regular<std::decay_t<T>>::type;
+
   /**
    * @brief Check the success of an MPI call.
    * @details It checks if the given error code returned by an MPI routine is equal to `MPI_SUCCESS`. If it isn't, it

--- a/c++/mpi/vector.hpp
+++ b/c++/mpi/vector.hpp
@@ -23,10 +23,10 @@
 
 #include "./mpi.hpp"
 #include "./ranges.hpp"
+#include "./utils.hpp"
 
 #include <mpi.h>
 
-#include <type_traits>
 #include <vector>
 
 namespace mpi {
@@ -35,27 +35,6 @@ namespace mpi {
    * @addtogroup coll_comm
    * @{
    */
-
-  namespace detail {
-
-    // Helper struct to get the regular type of a type.
-    template <typename T, typename Enable = void> struct _regular {
-      using type = T;
-    };
-
-    // Spezialization of _regular for types with a `regular_type` type alias.
-    template <typename T> struct _regular<T, std::void_t<typename T::regular_type>> {
-      using type = typename T::regular_type;
-    };
-
-  } // namespace detail
-
-  /**
-   * @ingroup utilities
-   * @brief Type trait to get the regular type of a type.
-   * @tparam T Type to check.
-   */
-  template <typename T> using regular_t = typename detail::_regular<std::decay_t<T>>::type;
 
   /**
    * @brief Implementation of an MPI broadcast for a std::vector.

--- a/c++/mpi/vector.hpp
+++ b/c++/mpi/vector.hpp
@@ -21,7 +21,8 @@
 
 #pragma once
 
-#include "./mpi.hpp"
+#include "./communicator.hpp"
+#include "./generic_communication.hpp"
 #include "./ranges.hpp"
 #include "./utils.hpp"
 

--- a/c++/mpi/vector.hpp
+++ b/c++/mpi/vector.hpp
@@ -85,7 +85,7 @@ namespace mpi {
    * @return std::vector containing the result of each individual reduction.
    */
   template <typename T>
-  std::vector<regular_t<T>> mpi_reduce(std::vector<T> const &v, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+  auto mpi_reduce(std::vector<T> const &v, communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     std::vector<regular_t<T>> res(c.rank() == root || all ? v.size() : 0);
     reduce_range(v, res, c, root, all, op);
     return res;
@@ -103,7 +103,7 @@ namespace mpi {
    * @param root Rank of the root process.
    * @return std::vector containing the result of the scatter operation.
    */
-  template <typename T> std::vector<T> mpi_scatter(std::vector<T> const &v, communicator c = {}, int root = 0) {
+  template <typename T> auto mpi_scatter(std::vector<T> const &v, communicator c = {}, int root = 0) {
     auto bsize = v.size();
     broadcast(bsize, c, root);
     std::vector<T> res(chunk_length(bsize, c.size(), c.rank()));
@@ -123,7 +123,7 @@ namespace mpi {
    * @param all Should all processes receive the result.
    * @return std::vector containing the result of the gather operation.
    */
-  template <typename T> std::vector<T> mpi_gather(std::vector<T> const &v, communicator c = {}, int root = 0, bool all = false) {
+  template <typename T> auto mpi_gather(std::vector<T> const &v, communicator c = {}, int root = 0, bool all = false) {
     long bsize = mpi::all_reduce(v.size(), c);
     std::vector<T> res(c.rank() == root || all ? bsize : 0);
     gather_range(v, res, bsize, c, root, all);

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -27,8 +27,6 @@
       <tab type="usergroup" url="@ref mpi_essentials" title="MPI essentials">
         <tab type="user" url="@ref mpi::communicator" title="communicator"/>
         <tab type="user" url="@ref mpi::environment" title="environment"/>
-        <tab type="user" url="@ref mpi::is_initialized" title="is_initialized"/>
-        <tab type="user" url="@ref mpi::has_env" title="has_env"/>
       </tab>
       <tab type="usergroup" url="@ref mpi_types_ops" title="MPI datatypes and operations">
         <tab type="usergroup" url="@ref mpi::mpi_type" title="mpi_type">
@@ -45,54 +43,19 @@
           <tab type="user" url="@ref mpi::mpi_type< unsigned long long >" title="mpi_type<unsigned long long>"/>
           <tab type="user" url="@ref mpi::mpi_type< std::tuple< Ts... > >" title="mpi_type<std::tuple>"/>
         </tab>
-        <tab type="user" url="@ref mpi::mpi_type_from_tie" title="mpi_type_from_tie"/>
-        <tab type="user" url="@ref mpi::get_mpi_type" title="get_mpi_type"/>
-        <tab type="user" url="@ref mpi::has_mpi_type" title="has_mpi_type"/>
-        <tab type="user" url="@ref mpi::map_C_function" title="map_C_function"/>
-        <tab type="user" url="@ref mpi::map_add" title="map_add"/>
       </tab>
-      <tab type="usergroup" url="@ref coll_comm" title="Collective MPI communication">
-      <tab type="user" url="@ref mpi::all_equal" title="all_equal"/>
-        <tab type="user" url="@ref mpi::all_gather" title="all_gather"/>
-        <tab type="user" url="@ref mpi::all_reduce" title="all_reduce"/>
-        <tab type="user" url="@ref mpi::all_reduce_in_place" title="all_reduce_in_place"/>
-        <tab type="usergroup" url="@ref mpi::broadcast" title="broadcast">
-          <tab type="user" url="@ref mpi::mpi_broadcast" title="mpi_broadcast"/>
-          <tab type="user" url="@ref mpi::mpi_broadcast(std::pair< T1, T2 >&amp;, mpi::communicator, int)" title="mpi_broadcast for std::pair"/>
-          <tab type="user" url="@ref mpi::mpi_broadcast(std::string&amp;, mpi::communicator, int)" title="mpi_broadcast for std::string"/>
-          <tab type="user" url="@ref mpi::mpi_broadcast(std::vector< T >&amp;, mpi::communicator, int)" title="mpi_broadcast for std::vector"/>
-        </tab>
-        <tab type="usergroup" url="@ref mpi::gather" title="gather">
-          <tab type="user" url="@ref mpi::mpi_gather" title="mpi_gather for std::vector"/>
-        </tab>
-        <tab type="usergroup" url="@ref mpi::reduce" title="reduce">
-          <tab type="user" url="@ref mpi::mpi_reduce" title="mpi_reduce"/>
-          <tab type="user" url="@ref mpi::mpi_reduce(std::pair< T1, T2 > const &amp;, mpi::communicator, int, bool, MPI_Op)" title="mpi_reduce for std::pair"/>
-          <tab type="user" url="@ref mpi::mpi_reduce(std::vector< T > const &amp;, mpi::communicator, int, bool, MPI_Op)" title="mpi_reduce for std::vector"/>
-        </tab>
-        <tab type="usergroup" url="@ref mpi::reduce_in_place" title="reduce_in_place">
-          <tab type="user" url="@ref mpi::mpi_reduce_in_place" title="mpi_reduce_in_place"/>
-          <tab type="user" url="@ref mpi::mpi_reduce_in_place(std::vector< T >&amp;, mpi::communicator, int, bool, MPI_Op)" title="mpi_reduce_in_place for std::vector"/>
-        </tab>
-        <tab type="usergroup" url="@ref mpi::scatter" title="scatter">
-          <tab type="user" url="@ref mpi::mpi_scatter" title="mpi_scatter"/>
-        </tab>
-      </tab>
+      <tab type="user" url="@ref coll_comm" title="Collective MPI communication"/>
       <tab type="usergroup" url="@ref mpi_lazy" title="Lazy MPI communication">
         <tab type="user" url="@ref mpi::lazy" title="lazy"/>
         <tab type="user" url="@ref mpi::tag::gather" title="gather tag"/>
         <tab type="user" url="@ref mpi::tag::reduce" title="reduce tag"/>
         <tab type="user" url="@ref mpi::tag::scatter" title="scatter tag"/>
-        <tab type="user" url="@ref mpi::is_mpi_lazy" title="is_mpi_lazy"/>
       </tab>
       <tab type="usergroup" url="@ref event_handling" title="Event handling">
         <tab type="user" url="@ref mpi::monitor" title="monitor"/>
       </tab>
       <tab type="usergroup" url="@ref utilities" title="Utilities">
-        <tab type="user" url="@ref mpi::regular_t" title="regular_t"/>
-        <tab type="user" url="@ref mpi::check_mpi_call" title="check_mpi_call"/>
-        <tab type="user" url="@ref mpi::chunk" title="chunk"/>
-        <tab type="user" url="@ref mpi::chunk_length" title="chunk_length"/>
+        <tab type="user" url="@ref mpi::contiguous_sized_range" title="contiguous_sized_range"/>
       </tab>
       <tab type="filelist" visible="yes" title="" intro=""/>
     </tab>

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -4,8 +4,8 @@
 
 **mpi** implements various high-level C++ wrappers around their low-level C counterparts.
 It is not intended as a full replacement for the C implementation.
-Instead it tries to help the user with the most common tasks like initializing and finalizing
-an @ref mpi::environment "MPI environment" or sending data via @ref coll_comm "collective communications".
+Instead it tries to help the user with the most common tasks like initializing and finalizing an @ref mpi::environment
+"MPI environment" or sending data via @ref coll_comm "collective communications".
 
 The following provides a detailed reference documentation grouped into logical units.
 
@@ -16,24 +16,27 @@ If you are looking for a specific function, class, etc., try using the search ba
 @ref mpi_essentials provide the user with two classes necessary for any MPI program:
 
 * The mpi::environment class is used to initialize and finialize the MPI execution environment.
-    It calls `MPI_Init` in its constructor and `MPI_Finalize` in its destructor.
-    There should be at most one instance in every program and it is usually created at the very beginning of the `main` function.
+  It calls `MPI_Init` in its constructor and `MPI_Finalize` in its destructor.
+  There should be at most one instance in every program and it is usually created at the very beginning of the `main`
+  function.
 
 * The mpi::communicator class is a simple wrapper around an `MPI_Comm` object.
-    Besides storing the `MPI_Comm` object, it also provides some convient functions for getting the size of the communicator,
-    the rank of the current process or for splitting an existing communicator.
+  Besides storing the `MPI_Comm` object, it also provides some convient functions for getting the size of the
+  communicator, the rank of the current process or for splitting an existing communicator.
+
+It further contains the convenient function mpi::is_initialized and the static boolean mpi::has_env.
 
 ## MPI datatypes and operations
 
-@ref mpi_types_ops map various C++ datatypes to MPI datatypes and help the user with registering their own datatypes to be
-used in MPI communications.
-Furthermore, it offers tools to simplify the creation of custom MPI operations usually required in `MPI_Reduce` or `MPI_Accumulate` functions.
+@ref mpi_types_ops map various C++ datatypes to MPI datatypes and help the user with registering their own datatypes to
+be used in MPI communications.
+Furthermore, it offers tools to simplify the creation of custom MPI operations usually required in `MPI_Reduce` or
+`MPI_Accumulate` functions.
 
 ## Collective MPI communication
 
 The following generic collective communications are defined in @ref coll_comm "Collective MPI communication":
 
-* @ref mpi::all_equal "all_equal"
 * @ref mpi::all_gather "all_gather"
 * @ref mpi::all_reduce "all_reduce"
 * @ref mpi::all_reduce_in_place "all_reduce_in_place"
@@ -43,8 +46,8 @@ The following generic collective communications are defined in @ref coll_comm "C
 * @ref mpi::reduce_in_place "reduce_in_place"
 * @ref mpi::scatter "scatter"
 
-They offer a much simpler interface than their MPI C library analogs. For example, the following broadcasts a `std::vector<double>`
-from the process with rank 0 to all others:
+They offer a much simpler interface than their MPI C library analogs.
+For example, the following broadcasts a `std::vector<double>` from the process with rank 0 to all others:
 
 ```cpp
 mpi::broadcast(vec);
@@ -56,18 +59,26 @@ Compare this with the call to the C library:
 MPI_Bcast(vec.data(), static_cast<int>(vec.size()), MPI_DOUBLE, 0, MPI_COMM_WORLD);
 ```
 
-Under the hood, the generic mpi::broadcast implementation calls the specialized @ref "mpi::mpi_broadcast(std::vector< T >&, mpi::communicator, int)".
-The other generic functions are implement in the same way.
+Under the hood, the generic mpi::broadcast implementation calls the specialized
+@ref "mpi::mpi_broadcast(std::vector< T >&, mpi::communicator, int)".
+The other generic functions are implemented in the same way.
 See the "Functions" section in @ref coll_comm to check which datatypes are supported out of the box.
 
 In case your datatype is not supported, you are free to provide your own specialization.
+
+Furthermore, there are several functions to simplify communicating generic, contiguous ranges:
+- mpi::broadcast_range,
+- mpi::gather_range,
+- mpi::reduce_in_place_range,
+- mpi::reduce_range and
+- mpi::scatter_range.
 
 ## Lazy MPI communication
 
 @ref mpi_lazy can be used to provied collective MPI communication for lazy expression types.
 Most users probably won't need to use this functionality directly.
 
-We refer the interested reader to [TRIQS/nda](https://github.com/TRIQS/nda/blob/unstable/c%2B%2B/nda/mpi/reduce.hpp) for more details.
+We refer the interested reader to [TRIQS/nda](https://triqs.github.io/nda/latest/group__av__mpi.html) for more details.
 
 ## Event handling
 
@@ -78,11 +89,8 @@ processes.
 
 ## Utilities
 
-@ref utilities is a collection of various other tools which do not fit into any other category above.
+@ref utilities is a collection of various other tools in **mpi** which do not fit into any other category above.
 
-The following utilities are defined in **mpi**:
-
-* @ref mpi::regular_t "regular_t"
-* @ref mpi::check_mpi_call "check_mpi_call"
-* @ref mpi::chunk "chunk"
-* @ref mpi::chunk_length "chunk_length"
+For users, the most useful of them is probably mpi::check_mpi_call.
+A wrapper function that checks the error code returned by MPI C library routines and throws an exception in case the
+code is `!= MPI_SUCCESS`.

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -32,25 +32,44 @@
 
 /**
  * @defgroup mpi_types_ops MPI datatypes and operations
- * @brief Specify supported MPI datatypes and provide tools to simplify the creation of user-defined MPI types and operations.
+ * @brief Specify supported MPI datatypes and provide tools to simplify the creation of user-defined MPI types and
+ * operations.
  *
- * @details See @ref ex3 for a detailed example.
+ * @details The following functionality is provided:
+ *
+ * - mpi::mpi_type and its specializations let **mpi** know that a certain type `T` can be used in MPI communications.
+ * The user is allowed to implement their own MPI compatible types and provide a specializtion of mpi::mpi_type.
+ * - mpi::get_mpi_type maps a given C++ type to its corresponding MPI datatype and mpi::has_mpi_type checks if a given
+ * type has a corresponding MPI datatype.
+ * - mpi::map_add and mpi::map_C_function can help the user to implement custom MPI operations.
+ *
+ * See @ref ex3 for a detailed example.
  */
 
 /**
  * @defgroup coll_comm Collective MPI communication
- * @brief Generic and specialized implementations for a subset of collective MPI communications (broadcast, reduce, gather, scatter).
+ * @brief Generic and specialized implementations for a subset of collective MPI communications (broadcast, reduce,
+ * gather, scatter).
  *
- * @details The generic functions (mpi::broadcast, mpi::reduce, mpi::scatter, ...) call their more specialized counterparts
- * (e.g. mpi::mpi_broadcast, mpi::mpi_reduce, mpi::mpi_scatter, ...).
+ * @details The generic functions (mpi::broadcast, mpi::reduce, mpi::scatter, ...) call their more specialized
+ * counterparts (e.g. mpi::mpi_broadcast, mpi::mpi_reduce, mpi::mpi_scatter, ...).
+ *
+ * **mpi** provides (some) implementations for
+ * - scalar types that have a corresponding mpi::mpi_type,
+ * - `std::vector` and `std::array` types with MPI compatible value types,
+ * - `std::string` and
+ * - `std::pair`.
+ *
+ * Furthermore, there are several functions to simplify communicating generic, contiguous ranges: mpi::broadcast_range,
+ * mpi::gather_range, mpi::reduce_in_place_range, mpi::reduce_range and mpi::scatter_range.
  */
 
 /**
  * @defgroup mpi_lazy Lazy MPI communication
  * @brief Allow specific types to use lazy MPI communication.
  *
- * @details See for example the [lazy reduce](https://github.com/TRIQS/nda/blob/unstable/c%2B%2B/nda/mpi/reduce.hpp)
- * in the [nda library](https://github.com/TRIQS/nda) for a reduce operation on a multi-dimensional array.
+ * @details Please look at the MPI interface in the [nda library](https://triqs.github.io/nda/latest/group__av__mpi.html)
+ * for more details.
  */
 
 /**

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 **mpi** is a header only library and installation is not necessary.
 However, it still supports the usual installation procedure using CMake.
 
-If you want to skip the installation step, you can go directly to @ref integration to see how you can integrate
-**mpi** into your own C++ project.
+If you want to skip the installation step, you can go directly to @ref integration to see how you can integrate **mpi**
+into your own C++ project.
 
 > **Note:** To guarantee reproducibility in scientific calculations, we strongly recommend the use of a stable
 > [release version](https://github.com/TRIQS/mpi/releases).
@@ -63,7 +63,7 @@ $ cd mpi.src && git tag
 Checkout the version of the code that you want:
 
 ```console
-$ git checkout 1.2.0
+$ git checkout 1.3.0
 ```
 
 and follow steps 2 to 4 above to compile the code.

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -3,8 +3,9 @@
 [TOC]
 
 **mpi** is a header only library.
-To use it in your own `C++` code, you simply have to include the relevant header files and
-tell your compiler/build system where it can find the necessary files.
+To use it in your own `C++` code, you simply have to include the relevant header files and tell your compiler/build
+system where it can find the necessary files.
+
 For example:
 
 ```cpp
@@ -19,9 +20,9 @@ In the following, we describe some common ways to achieve this (with special foc
 
 @subsection fetch FetchContent
 
-If you use [CMake](https://cmake.org/) to build your source code, it is recommended to fetch the source code directly from the
-[Github repository](https://github.com/TRIQS/mpi) using CMake's [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)
-module:
+If you use [CMake](https://cmake.org/) to build your source code, it is recommended to fetch the source code directly
+from the [Github repository](https://github.com/TRIQS/mpi) using CMake's
+[FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html) module:
 
 ```cmake
 cmake_minimum_required(VERSION 3.20)
@@ -32,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
   mpi
   GIT_REPOSITORY https://github.com/TRIQS/mpi.git
-  GIT_TAG        1.2.x
+  GIT_TAG        1.3.x
 )
 FetchContent_MakeAvailable(mpi)
 
@@ -42,12 +43,13 @@ target_link_libraries(my_executable mpi::mpi_c)
 ```
 
 Note that the above will also build [goolgetest](https://github.com/google/googletest) and the unit tests for **mpi**.
-To disable this, you can put `set(Build_Tests OFF CACHE BOOL "" FORCE)` before fetching the content or by specifying `-DBuild_Tests=OFF` on the command line.
+To disable this, you can put `set(Build_Tests OFF CACHE BOOL "" FORCE)` before fetching the content or by specifying
+`-DBuild_Tests=OFF` on the command line.
 
 @subsection find_package find_package
 
-If you have already installed **mpi** on your system by following the instructions from the @ref installation page, you can also make
-use of CMake's [find_package](https://cmake.org/cmake/help/latest/command/find_package.html) command.
+If you have already installed **mpi** on your system by following the instructions from the @ref installation page, you
+can also make use of CMake's [find_package](https://cmake.org/cmake/help/latest/command/find_package.html) command.
 This has the advantage that you don't need to download anything, i.e. no internet connection is required.
 
 Let's assume that **mpi** has been installed to `path_to_install_dir`.
@@ -65,8 +67,9 @@ add_executable(my_executable main.cpp)
 target_link_libraries(my_executable mpi::mpi_c)
 ```
 
-In case, CMake cannot find the package, you might have to tell it where to look for the `mpi-config.cmake` file by setting the variable
-`mpi_DIR` to `path_to_install_dir/lib/cmake/mpi` or by sourcing the provided `mpivars.sh` before running CMake:
+In case, CMake cannot find the package, you might have to tell it where to look for the `mpi-config.cmake` file by
+setting the variable `mpi_DIR` to `path_to_install_dir/lib/cmake/mpi` or by sourcing the provided `mpivars.sh` before
+running CMake:
 
 ```console
 $ source path_to_install_dir/share/mpi/mpivars.sh
@@ -74,7 +77,8 @@ $ source path_to_install_dir/share/mpi/mpivars.sh
 
 @subsection add_sub add_subdirectory
 
-You can also integrate **mpi** into our CMake project by placing the entire source tree in a subdirectory and call `add_subdirectory()`:
+You can also integrate **mpi** into our CMake project by placing the entire source tree in a subdirectory and call
+`add_subdirectory()`:
 
 ```cmake
 cmake_minimum_required(VERSION 3.20)

--- a/doc/issues.md
+++ b/doc/issues.md
@@ -5,17 +5,14 @@
 Please report all problems and bugs directly at the [GitHub issues page](https://github.com/TRIQS/mpi/issues).
 In order to make it easier for us to solve the issue please follow these guidelines:
 
-1. In all cases specify which version of the application you are using. You can
-   find the version number in the file `CMakeLists.txt` at the root of the
-   application sources.
+1. In all cases specify which version of the application you are using. You can find the version number in the file
+   `CMakeLists.txt` at the root of the application sources.
 
-2. If you have a problem during the installation, give us information about
-   your operating system and the compiler you are using. Include the outputs of
-   the `cmake` and `make` commands as well as the `CMakeCache.txt` file
-   which is in the build directory. Please include these outputs in a
-   [gist](http://gist.github.com/>) file referenced in the issue.
+2. If you have a problem during the installation, give us information about your operating system and the compiler you
+   are using. Include the outputs of the `cmake` and `make` commands as well as the `CMakeCache.txt` file which is in
+   the build directory. Please include these outputs in a [gist](http://gist.github.com/>) file referenced in the issue.
 
-3. If you are experiencing a problem during the execution of the application, provide
-   a script which allows to quickly reproduce the problem.
+3. If you are experiencing a problem during the execution of the application, provide a script which allows to quickly
+   reproduce the problem.
 
 Thanks!

--- a/doc/overview.md.in
+++ b/doc/overview.md.in
@@ -28,10 +28,11 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-**mpi** is a minimal C++ wrapper around the MPI C library and provides only a small subset of the functionality defined in the MPI standard.
+**mpi** is a minimal C++ wrapper around the MPI C library and provides only a small subset of the functionality defined
+in the MPI standard.
 
-The main purpose of the library is to simplify the most common tasks like initializing/finalizing the MPI execution environment or performing
-non-blocking collective communications.
+The main purpose of the library is to simplify the most common tasks like initializing/finalizing the MPI execution
+environment or performing non-blocking collective communications.
 
 For more advanced tasks, the user can always resort to the underlying MPI C-implementation.
 

--- a/test/c++/mpi_array.cpp
+++ b/test/c++/mpi_array.cpp
@@ -18,9 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <itertools/itertools.hpp>
-#include <mpi/pair.hpp>
-#include <mpi/string.hpp>
-#include <mpi/array.hpp>
+#include <mpi/mpi.hpp>
 
 #include <complex>
 #include <numeric>

--- a/test/c++/mpi_array.cpp
+++ b/test/c++/mpi_array.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Nils Wentzell
+
+#include "./non_mpi_t.hpp"
+
+#include <gtest/gtest.h>
+#include <itertools/itertools.hpp>
+#include <mpi/pair.hpp>
+#include <mpi/string.hpp>
+#include <mpi/array.hpp>
+
+#include <complex>
+#include <numeric>
+#include <tuple>
+
+TEST(MPI, ArrayBroadcastMPIType) {
+  // broadcast an array with an MPI type
+  mpi::communicator world;
+  std::array<int, 5> arr{};
+  if (world.rank() == 0) std::iota(arr.begin(), arr.end(), 0);
+  mpi::broadcast(arr, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i);
+}
+
+TEST(MPI, ArrayBroadcastTypeWithSpezializedMPIBroadcast) {
+  // broadcast an array with a type that has a specialized mpi_broadcast
+  mpi::communicator world;
+  std::array<non_mpi_t, 5> arr{};
+  if (world.rank() == 0) {
+    for (int i = 0; i < 5; ++i) arr[i].a = i;
+  }
+  mpi::broadcast(arr, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i].a, i);
+}
+
+TEST(MPI, ArrayReduceInPlaceMPIType) {
+  // in-place reduce an array with an MPI type
+  mpi::communicator world;
+  std::array<int, 5> arr{0, 1, 2, 3, 4};
+  mpi::reduce_in_place(arr, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i);
+
+  // in-place allreduce an array with an MPI type
+  std::iota(arr.begin(), arr.end(), 0);
+  mpi::all_reduce_in_place(arr, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i * world.size());
+}
+
+TEST(MPI, ArrayReduceInPlaceTypeWithSpezializedMPIReduceInPlace) {
+  // in-place reduce an array with a type that has a specialized mpi_reduce_in_place
+  mpi::communicator world;
+  std::array<non_mpi_t, 5> arr{};
+  for (int i = 0; i < 5; ++i) arr[i].a = i;
+  mpi::reduce_in_place(arr, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i].a, i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i].a, i);
+
+  // in-place allreduce an array with a type that has a specialized mpi_reduce_in_place
+  for (int i = 0; i < 5; ++i) arr[i].a = i;
+  mpi::all_reduce_in_place(arr, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i].a, i * world.size());
+}
+
+TEST(MPI, ArrayReduceMPIType) {
+  // reduce an array with complex numbers
+  mpi::communicator world;
+  using arr_type = std::array<std::complex<double>, 7>;
+  const int size = 7;
+  arr_type arr{};
+  for (int i = 0; i < size; ++i) arr[i] = std::complex<double>(i, -i);
+  auto arr_reduced = mpi::reduce(arr, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < size; ++i) EXPECT_EQ(arr_reduced[i], std::complex<double>(i * world.size(), -i * world.size()));
+  else
+    EXPECT_EQ(arr_reduced, arr_type{});
+
+  // allreduce an array with complex numbers
+  auto arr_reduced_all = mpi::all_reduce(arr, world);
+  for (int i = 0; i < size; ++i) EXPECT_EQ(arr_reduced_all[i], std::complex<double>(i * world.size(), -i * world.size()));
+}
+
+TEST(MPI, EmptyArrayReduce) {
+  // reduce an empty array
+  mpi::communicator world;
+  std::array<double, 0> arr{};
+  std::ignore = mpi::reduce(arr, world);
+}
+
+MPI_TEST_MAIN;

--- a/test/c++/mpi_custom.cpp
+++ b/test/c++/mpi_custom.cpp
@@ -45,23 +45,6 @@ template <> struct mpi::mpi_type<custom_cplx> : mpi::mpi_type_from_tie<custom_cp
 // stand-alone add function (the same as the operator+ above)
 custom_cplx add(custom_cplx const &x, custom_cplx const &y) { return x + y; }
 
-// needs to be in the mpi namespace for ADL to work
-namespace mpi {
-
-  // specialize mpi_reduce for std::array
-  template <typename T, size_t N>
-  std::array<T, N> mpi_reduce(std::array<T, N> const &arr, mpi::communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
-    std::array<T, N> res{};
-    if (all) {
-      MPI_Allreduce(arr.data(), res.data(), N, mpi::mpi_type<T>::get(), op, c.get());
-    } else {
-      MPI_Reduce(arr.data(), res.data(), N, mpi::mpi_type<T>::get(), op, root, c.get());
-    }
-    return res;
-  }
-
-}
-
 TEST(MPI, CustomTypeMapAdd) {
   mpi::communicator world;
   int rank = world.rank();

--- a/test/c++/mpi_generic.cpp
+++ b/test/c++/mpi_generic.cpp
@@ -17,7 +17,6 @@
 
 #include <gtest/gtest.h>
 #include <mpi/mpi.hpp>
-#include <mpi/vector.hpp>
 
 TEST(MPI, AllEqual) {
   // check if a value is equal on all ranks

--- a/test/c++/mpi_monitor.cpp
+++ b/test/c++/mpi_monitor.cpp
@@ -15,7 +15,7 @@
 // Authors: Philipp Dumitrescu, Thomas Hahn, Olivier Parcollet
 
 #include <gtest/gtest.h>
-#include <mpi/monitor.hpp>
+#include <mpi/mpi.hpp>
 #include <mpi.h>
 
 #include <algorithm>

--- a/test/c++/mpi_pair.cpp
+++ b/test/c++/mpi_pair.cpp
@@ -15,8 +15,7 @@
 // Authors: Thomas Hahn, Nils Wentzell
 
 #include <gtest/gtest.h>
-#include <mpi/pair.hpp>
-#include <mpi/string.hpp>
+#include <mpi/mpi.hpp>
 
 #include <complex>
 #include <string>

--- a/test/c++/mpi_ranges.cpp
+++ b/test/c++/mpi_ranges.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2022-2024 Simons Foundation
+// Copyright (c) 2022 Hugo U.R. Strand
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Hugo U.R. Strand
+
+#include "./non_mpi_t.hpp"
+
+#include <gtest/gtest.h>
+#include <mpi/ranges.hpp>
+#include <mpi/vector.hpp>
+
+#include <array>
+#include <numeric>
+#include <vector>
+
+TEST(MPI, RangesBroadcastMPIType) {
+  // broadcast a range with an MPI type
+  mpi::communicator world;
+  std::array<int, 5> arr{};
+  if (world.rank() == 0) {
+    for (int i = 0; i < 5; ++i) arr[i] = i;
+  }
+  mpi::broadcast_range(arr, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i);
+}
+
+TEST(MPI, RangesBroadcastTypeWithSpezializedMPIBroadcast) {
+  // broadcast a range with a type that has a specialized mpi_broadcast
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5);
+  if (world.rank() == 0) {
+    for (int i = 0; i < 5; ++i) vec[i].a = i;
+  }
+  mpi::broadcast_range(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i);
+}
+
+TEST(MPI, RangesReduceInPlaceMPIType) {
+  // in-place reduce a range with an MPI type
+  mpi::communicator world;
+  std::array<int, 5> arr{0, 1, 2, 3, 4};
+  mpi::reduce_in_place_range(arr, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i);
+
+  // in-place allreduce a range with an MPI type
+  arr = {0, 1, 2, 3, 4};
+  mpi::reduce_in_place_range(arr, world, 0, true);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr[i], i * world.size());
+}
+
+TEST(MPI, RangesReduceInPlaceTypeWithSpezializedMPIReduceInPlace) {
+  // in-place reduce a range with a type that has a specialized mpi_reduce_in_place
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5);
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::reduce_in_place_range(vec, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i);
+
+  // in-place allreduce a range with a type that has a specialized mpi_reduce_in_place
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::reduce_in_place_range(vec, world, 0, true);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i * world.size());
+}
+
+TEST(MPI, RangesReduceMPIType) {
+  // reduce a range with an MPI type
+  mpi::communicator world;
+  std::array<int, 5> arr{0, 1, 2, 3, 4}, arr_red{};
+  mpi::reduce_range(arr, arr_red, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr_red[i], i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(arr_red[i], 0);
+
+  // allreduce a range with an MPI type
+  arr     = {0, 1, 2, 3, 4};
+  arr_red = {};
+  mpi::reduce_range(arr, arr_red, world, 0, true);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(arr_red[i], i * world.size());
+}
+
+TEST(MPI, RangesReduceTypeWithSpezializedMPIReduceInPlace) {
+  // reduce a range with a type that has a specialized mpi_reduce_in_place
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5, non_mpi_t{}), vec_red(5, non_mpi_t{});
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::reduce_range(vec, vec_red, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec_red[i].a, i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec_red[i].a, non_mpi_t{}.a);
+
+  // allreduce a range with a type that has a specialized mpi_reduce_in_place
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::reduce_range(vec, vec_red, world, 0, true);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec_red[i].a, i * world.size());
+}
+
+TEST(MPI, RangesScatterMPIType) {
+  // scatter a range with an MPI type
+  mpi::communicator world;
+  auto const rank = world.rank();
+  auto sizes      = std::vector<int>(world.size());
+  for (int i = 0; i < world.size(); ++i) sizes[i] = static_cast<int>(mpi::chunk_length(10, world.size(), i));
+  auto acc_sizes = std::vector<int>(world.size() + 1, 0);
+  std::partial_sum(sizes.begin(), sizes.end(), std::next(acc_sizes.begin()));
+  std::vector<int> vec(10, 0), vec_scattered(sizes[rank], 0);
+  if (rank == 0) {
+    for (int i = 0; i < 10; ++i) vec[i] = i;
+  }
+  mpi::scatter_range(vec, vec_scattered, 10, world, 0);
+  for (int i = 0; i < sizes[rank]; ++i) EXPECT_EQ(vec_scattered[i], i + acc_sizes[rank]);
+}
+
+TEST(MPI, RangesGatherMPIType) {
+  // gather a range with an MPI type
+  mpi::communicator world;
+  auto const rank          = world.rank();
+  auto const gathered_size = (world.size() + 1) * world.size() / 2;
+  std::vector<int> vec(world.rank() + 1, 0), vec_gathered(gathered_size, 0);
+  std::iota(vec.begin(), vec.end(), rank * (rank + 1) / 2);
+  mpi::gather_range(vec, vec_gathered, gathered_size, world, 0, false);
+  if (rank == 0) {
+    for (int i = 0; i < gathered_size; ++i) EXPECT_EQ(vec_gathered[i], i);
+  }
+}
+
+TEST(MPI, RangesGatherTypeWithSpecializedMPIBroadcast) {
+  // gather a range with a type that has a specialized mpi_broadcast
+  mpi::communicator world;
+  auto const rank          = world.rank();
+  auto const gathered_size = (world.size() + 1) * world.size() / 2;
+  std::vector<non_mpi_t> vec(world.rank() + 1, non_mpi_t{}), vec_gathered(gathered_size, non_mpi_t{});
+  for (int i = 0; i < vec.size(); ++i) vec[i].a = i + rank * (rank + 1) / 2;
+
+  // providing the size of the output range
+  mpi::gather_range(vec, vec_gathered, gathered_size, world, 0, true);
+  for (int i = 0; i < gathered_size; ++i) EXPECT_EQ(vec_gathered[i].a, i);
+}
+
+MPI_TEST_MAIN;

--- a/test/c++/mpi_ranges.cpp
+++ b/test/c++/mpi_ranges.cpp
@@ -18,8 +18,7 @@
 #include "./non_mpi_t.hpp"
 
 #include <gtest/gtest.h>
-#include <mpi/ranges.hpp>
-#include <mpi/vector.hpp>
+#include <mpi/mpi.hpp>
 
 #include <array>
 #include <numeric>

--- a/test/c++/mpi_string.cpp
+++ b/test/c++/mpi_string.cpp
@@ -31,4 +31,25 @@ TEST(MPI, StringBroadcast) {
   EXPECT_EQ(s, std::string{"Hello World"});
 }
 
+TEST(MPI, StringGather) {
+  // gather a string
+  mpi::communicator world;
+  std::string s{}, exp_s{};
+  for (int i = 0; i < world.size(); ++i) {
+    for (int j = 0; j < i + 1; ++j) exp_s += "a";
+    exp_s += std::to_string(i);
+  }
+  for (int i = 0; i < world.rank() + 1; ++i) s += "a";
+  s += std::to_string(world.rank());
+
+  // gather only on root
+  auto s_gathered = mpi::gather(s);
+  if (world.rank() == 0) EXPECT_EQ(s_gathered, exp_s);
+  else EXPECT_TRUE(s_gathered.empty());
+
+  // gather on all processes
+  auto s_gathered_all = mpi::all_gather(s);
+  EXPECT_EQ(s_gathered_all, exp_s);
+}
+
 MPI_TEST_MAIN;

--- a/test/c++/mpi_string.cpp
+++ b/test/c++/mpi_string.cpp
@@ -15,7 +15,7 @@
 // Authors: Thomas Hahn, Nils Wentzell
 
 #include <gtest/gtest.h>
-#include <mpi/string.hpp>
+#include <mpi/mpi.hpp>
 
 #include <string>
 

--- a/test/c++/mpi_vector.cpp
+++ b/test/c++/mpi_vector.cpp
@@ -14,6 +14,8 @@
 //
 // Authors: Thomas Hahn, Nils Wentzell
 
+#include "./non_mpi_t.hpp"
+
 #include <gtest/gtest.h>
 #include <itertools/itertools.hpp>
 #include <mpi/pair.hpp>
@@ -21,26 +23,101 @@
 #include <mpi/vector.hpp>
 
 #include <complex>
+#include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
 
-TEST(MPI, VectorReduce) {
-  // reduce a vector of complex numbers
+TEST(MPI, VectorBroadcastMPIType) {
+  // broadcast a vector with an MPI type
+  mpi::communicator world;
+  std::vector<int> vec(5, 0);
+  if (world.rank() == 0) {
+    std::iota(vec.begin(), vec.end(), 0);
+  } else {
+    vec.clear();
+  }
+  mpi::broadcast(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i);
+}
+
+TEST(MPI, VectorBroadcastTypeWithSpezializedMPIBroadcast) {
+  // broadcast a vector with a type that has a specialized mpi_broadcast
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5);
+  if (world.rank() == 0) {
+    for (int i = 0; i < 5; ++i) vec[i].a = i;
+  }
+  mpi::broadcast(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i);
+}
+
+TEST(MPI, VectorReduceInPlaceMPIType) {
+  // in-place reduce a vector with an MPI type
+  mpi::communicator world;
+  std::vector<int> vec{0, 1, 2, 3, 4};
+  mpi::reduce_in_place(vec, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i);
+
+  // in-place allreduce a range with an MPI type
+  std::iota(vec.begin(), vec.end(), 0);
+  mpi::all_reduce_in_place(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i * world.size());
+}
+
+TEST(MPI, VectorReduceInPlaceTypeWithSpezializedMPIReduceInPlace) {
+  // in-place reduce a vector with a type that has a specialized mpi_reduce_in_place
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5);
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::reduce_in_place(vec, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i * world.size());
+  else
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i);
+
+  // in-place allreduce a vector with a type that has a specialized mpi_reduce_in_place
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  mpi::all_reduce_in_place(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i].a, i * world.size());
+}
+
+TEST(MPI, VectorReduceMPIType) {
+  // reduce a vector with complex numbers
   mpi::communicator world;
   using vec_type = std::vector<std::complex<double>>;
-
   const int size = 7;
-  vec_type vec(size), reduced_vec;
+  vec_type vec(size);
+  for (int i = 0; i < size; ++i) vec[i] = std::complex<double>(i, -i);
+  auto vec_reduced = mpi::reduce(vec, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < size; ++i) EXPECT_EQ(vec_reduced[i], std::complex<double>(i * world.size(), -i * world.size()));
+  else
+    EXPECT_TRUE(vec_reduced.empty());
 
-  for (int i = 0; i < size; ++i) vec[i] = i;
+  // allreduce a vector with complex numbers
+  vec_reduced = mpi::all_reduce(vec, world);
+  for (int i = 0; i < size; ++i) EXPECT_EQ(vec_reduced[i], std::complex<double>(i * world.size(), -i * world.size()));
+}
 
-  reduced_vec = mpi::all_reduce(vec, world);
+TEST(MPI, VectorReduceTypeWithSpezializedMPIReduce) {
+  // reduce a vector with a type that has a specialized mpi_reduce
+  mpi::communicator world;
+  std::vector<non_mpi_t> vec(5);
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  auto vec_reduced = mpi::reduce(vec, world);
+  if (world.rank() == 0)
+    for (int i = 0; i < 5; ++i) EXPECT_EQ(vec_reduced[i].a, i * world.size());
+  else
+    EXPECT_TRUE(vec_reduced.empty());
 
-  vec_type exp_vec(size);
-  for (int i = 0; i < size; ++i) exp_vec[i] = world.size() * i;
-
-  EXPECT_EQ(reduced_vec, exp_vec);
+  // allreduce a vector with a type that has a specialized mpi_reduce
+  for (int i = 0; i < 5; ++i) vec[i].a = i;
+  auto vec_reduced_all = mpi::all_reduce(vec, world);
+  for (int i = 0; i < 5; ++i) EXPECT_EQ(vec_reduced_all[i].a, i * world.size());
 }
 
 TEST(MPI, EmptyVectorReduce) {
@@ -53,9 +130,7 @@ TEST(MPI, EmptyVectorReduce) {
 TEST(MPI, VectorGatherScatter) {
   // scatter and gather a vector of complex numbers
   mpi::communicator world;
-
   std::vector<std::complex<double>> vec(7), scattered_vec(7), gathered_vec(7, {0.0, 0.0});
-
   for (auto [i, v_i] : itertools::enumerate(vec)) v_i = static_cast<double>(i) + 1.0;
 
   scattered_vec = mpi::scatter(vec, world);
@@ -69,16 +144,18 @@ TEST(MPI, VectorGatherScatter) {
   EXPECT_EQ(vec, gathered_vec);
 }
 
-TEST(MPI, VectorGatherScatterPair) {
-  // scatter and gather a vector of pairs
-  auto v = std::vector<std::pair<int, std::string>>{{1, "one"}, {2, "two"}, {3, "three"}, {4, "four"}, {5, "five"}};
-
-  auto vsct = mpi::scatter(v);
-  auto vgth = mpi::all_gather(vsct);
-
+TEST(MPI, VectorGatherPair) {
+  // gather a vector of pairs
   mpi::communicator world;
-  if (world.size() > 1) { EXPECT_NE(vsct, vgth); }
-  EXPECT_EQ(v, vgth);
+  auto const rank          = world.rank();
+  auto const gathered_size = (world.size() + 1) * world.size() / 2;
+  std::vector<std::pair<int, std::string>> vec(world.rank() + 1);
+  for (int i = 0; i < vec.size(); ++i) {
+    vec[i].first  = i + rank * (rank + 1) / 2;
+    vec[i].second = std::to_string(vec[i].first);
+  }
+  auto vec_gathered = mpi::all_gather(vec, world);
+  for (int i = 0; i < gathered_size; ++i) EXPECT_EQ(vec_gathered[i], std::make_pair(i, std::to_string(i)));
 }
 
 TEST(MPI, VectorGatherOnlyOnRoot) {
@@ -102,22 +179,6 @@ TEST(MPI, VectorScatterSizeZero) {
   if (world.rank() == 0) v.clear();
   auto res = mpi::scatter(v, world);
   EXPECT_TRUE(res.empty());
-}
-
-TEST(MPI, VectorReduceSizeZero) {
-  // pass a vector of size 0 to reduce
-  mpi::communicator world;
-  std::vector<int> v = {1, 2, 3};
-  if (world.rank() == 0) v.clear();
-  if (world.size() > 1) { EXPECT_THROW(mpi::reduce(v, world), std::runtime_error); }
-}
-
-TEST(MPI, VectorReduceInPlaceSizeZero) {
-  // pass a vector of size 0 to reduce_in_place
-  mpi::communicator world;
-  std::vector<int> v = {1, 2, 3};
-  if (world.rank() == 0) v.clear();
-  if (world.size() > 1) { EXPECT_THROW(mpi::all_reduce_in_place(v, world), std::runtime_error); }
 }
 
 MPI_TEST_MAIN;

--- a/test/c++/mpi_vector.cpp
+++ b/test/c++/mpi_vector.cpp
@@ -18,9 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <itertools/itertools.hpp>
-#include <mpi/pair.hpp>
-#include <mpi/string.hpp>
-#include <mpi/vector.hpp>
+#include <mpi/mpi.hpp>
 
 #include <complex>
 #include <numeric>

--- a/test/c++/mpi_vector.cpp
+++ b/test/c++/mpi_vector.cpp
@@ -62,7 +62,7 @@ TEST(MPI, VectorReduceInPlaceMPIType) {
   else
     for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i);
 
-  // in-place allreduce a range with an MPI type
+  // in-place allreduce a vector with an MPI type
   std::iota(vec.begin(), vec.end(), 0);
   mpi::all_reduce_in_place(vec, world);
   for (int i = 0; i < 5; ++i) EXPECT_EQ(vec[i], i * world.size());

--- a/test/c++/non_mpi_t.hpp
+++ b/test/c++/non_mpi_t.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2022-2024 Simons Foundation
+// Copyright (c) 2022 Hugo U.R. Strand
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Hugo U.R. Strand
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <mpi/mpi.hpp>
+
+struct non_mpi_t {
+  int a{1};
+};
+
+// needs to be in the mpi namespace for ADL to work
+namespace mpi {
+
+  // specialize mpi_broadcast for foo
+  void mpi_broadcast(non_mpi_t &f, mpi::communicator c = {}, int root = 0) { broadcast(f.a, c, root); }
+
+  // specialize mpi_reduce_in_place for foo
+  void mpi_reduce_in_place(non_mpi_t &f, mpi::communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    if (all) {
+      all_reduce_in_place(f.a, c, op);
+    } else {
+      reduce_in_place(f.a, c, root, false, op);
+    }
+  }
+
+  // specialize mpi_reduce for foo
+  non_mpi_t mpi_reduce(non_mpi_t const &f, mpi::communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+    non_mpi_t res{};
+    if (all) {
+      res.a = all_reduce(f.a, c, op);
+    } else {
+      res.a = reduce(f.a, c, root, false, op);
+    }
+    return (c.rank() == root || all ? res : non_mpi_t{});
+  }
+
+} // namespace mpi


### PR DESCRIPTION
- Add a `broadcast`, `reduce_in_place`, `reduce`, `scatter` and `gather` function for contiguous and sized ranges  